### PR TITLE
[MTHD-1587] routes and types updated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "method-node",
-  "version": "0.2.16",
+  "version": "0.2.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "method-node",
-      "version": "0.2.16",
+      "version": "0.2.19",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "method-node",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "description": "Node.js library for the Method API",
   "main": "dist/index.ts",
   "module": "dist/index.mjs",

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -134,8 +134,6 @@ export default class Resource<SubResources> extends ExtensibleFunction<SubResour
   ): Promise<Response> {
     const _requestConfig = { headers: {} };
     if (requestConfig.idempotency_key) _requestConfig.headers = { 'Idempotency-Key': requestConfig.idempotency_key };
-    console.log(path)
-    console.log(data)
     return (await this.client.post(path, data)).data.data;
   }
 
@@ -146,7 +144,7 @@ export default class Resource<SubResources> extends ExtensibleFunction<SubResour
   protected async _update<Response, Data>(data: Data): Promise<Response> {
     return (await this.client.put('', data)).data.data;
   }
-  
+
   protected async _updateWithSubPath<Response, Data>(
     path: string,
     data: Data,

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -134,7 +134,8 @@ export default class Resource<SubResources> extends ExtensibleFunction<SubResour
   ): Promise<Response> {
     const _requestConfig = { headers: {} };
     if (requestConfig.idempotency_key) _requestConfig.headers = { 'Idempotency-Key': requestConfig.idempotency_key };
-
+    console.log(path)
+    console.log(data)
     return (await this.client.post(path, data)).data.data;
   }
 
@@ -144,6 +145,17 @@ export default class Resource<SubResources> extends ExtensibleFunction<SubResour
 
   protected async _update<Response, Data>(data: Data): Promise<Response> {
     return (await this.client.put('', data)).data.data;
+  }
+  
+  protected async _updateWithSubPath<Response, Data>(
+    path: string,
+    data: Data,
+    requestConfig: IRequestConfig = {},
+  ): Promise<Response> {
+    const _requestConfig = { headers: {} };
+    if (requestConfig.idempotency_key) _requestConfig.headers = { 'Idempotency-Key': requestConfig.idempotency_key };
+
+    return (await this.client.put(path, data)).data.data;
   }
 
   protected async _delete<Response>(id: string): Promise<Response> {
@@ -158,16 +170,8 @@ export default class Resource<SubResources> extends ExtensibleFunction<SubResour
     return (await this.client.post(`/${id}`, data)).data.data;
   }
 
-  protected async _createAuthSession<Response>(id: string): Promise<Response> {
-    return (await this.client.post(`/${id}/auth_session`)).data.data;
-  }
-
   protected async _updateAuthSession<Response, Data>(id: string, data: Data): Promise<Response> {
     return (await this.client.put(`/${id}/auth_session`, data)).data;
-  }
-
-  protected async _refreshCapabilities<Response>(id: string): Promise<Response> {
-    return (await this.client.post(`/${id}/refresh_capabilities`)).data;
   }
 }
 

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -157,6 +157,18 @@ export default class Resource<SubResources> extends ExtensibleFunction<SubResour
   protected async _postWithId<Response, Data>(id: string, data: Data): Promise<Response> {
     return (await this.client.post(`/${id}`, data)).data.data;
   }
+
+  protected async _createAuthSession<Response>(id: string): Promise<Response> {
+    return (await this.client.post(`/${id}/auth_session`)).data.data;
+  }
+
+  protected async _updateAuthSession<Response, Data>(id: string, data: Data): Promise<Response> {
+    return (await this.client.put(`/${id}/auth_session`, data)).data;
+  }
+
+  protected async _refreshCapabilities<Response>(id: string): Promise<Response> {
+    return (await this.client.post(`/${id}/refresh_capabilities`)).data;
+  }
 }
 
 export interface IResourceError {

--- a/src/resources/Account/index.ts
+++ b/src/resources/Account/index.ts
@@ -25,11 +25,15 @@ export type TAccountSubTypes =
 export const AccountStatuses = {
   disabled: 'disabled',
   active: 'active',
+  processing: 'processing',
+  closed: 'closed'
 };
 
 export type TAccountStatuses =
   | 'disabled'
-  | 'active';
+  | 'active'
+  | 'processing'
+  | 'closed';
 
 export const AccountCapabilities = {
   payments_receive: 'payments:receive',
@@ -92,6 +96,7 @@ export interface IAccountListOpts {
   from_date?: string | null;
   page?: number | string | null;
   page_limit?: number | string | null;
+  page_cursor?: string | null;
   status?: string | null;
   type?: string | null;
   holder_id?: string | null;

--- a/src/resources/Connection/index.ts
+++ b/src/resources/Connection/index.ts
@@ -57,10 +57,6 @@ export default class Connection extends Resource<void> {
     return super._updateWithId<IConnection, IConnectionUpdateOpts>(id, opts);
   }
 
-  async getAccounts(id: string) {
-    return super._getWithSubPath<IAccount[]>(`/${id}/accounts`);
-  }
-
   async getPublicAccountTokens(id: string) {
     return super._getWithSubPath<string[]>(`/${id}/public_account_tokens`);
   }

--- a/src/resources/Entity/index.ts
+++ b/src/resources/Entity/index.ts
@@ -88,6 +88,7 @@ export interface IEntity {
   individual: IEntityIndividual | null;
   corporation: IEntityCorporation | null;
   receive_only: IEntityReceiveOnly | null;
+  capabilities: TEntityCapabilities[];
   available_capabilities: TEntityCapabilities[];
   pending_capabilities: TEntityCapabilities[];
   address: IEntityAddress;
@@ -198,14 +199,14 @@ export default class Entity extends Resource<void> {
   }
 
   async createAuthSession(id: string) {
-    return super._createAuthSession<IEntityQuestionResponse>(id);
+    return super._createWithSubPath<IEntityQuestionResponse, {}>(`/${id}/auth_session`, {});
   }
 
   async updateAuthSession(id: string, opts: IEntityUpdateAuthOpts) {
-    return super._updateAuthSession<IEntityUpdateAuthResponse, IEntityUpdateAuthOpts>(id, opts)
+    return super._updateWithSubPath<IEntityUpdateAuthResponse, IEntityUpdateAuthOpts>(`/${id}/auth_session`, opts)
   }
 
   async refreshCapabilities(id: string) {
-    return super._refreshCapabilities<IEntity>(id);
+    return super._createWithSubPath<IEntity, {}>(`/${id}/refresh_capabilities`, {});
   }
 };

--- a/src/resources/Entity/index.ts
+++ b/src/resources/Entity/index.ts
@@ -24,12 +24,14 @@ export const EntityCapabilities = {
   payments_send: 'payments:send',
   payments_receive: 'payments:receive',
   payments_limited_send: 'payments:limited-send',
+  data_retrieve: 'data:retrieve'
 };
 
 export type TEntityCapabilities =
   | 'payments:send'
   | 'payments:receive'
-  | 'payments:limited-send';
+  | 'payments:limited-send'
+  | 'data:retrieve';
 
 export const EntityStatuses = {
    active: 'active',
@@ -86,7 +88,8 @@ export interface IEntity {
   individual: IEntityIndividual | null;
   corporation: IEntityCorporation | null;
   receive_only: IEntityReceiveOnly | null;
-  capabilities: TEntityCapabilities[];
+  available_capabilities: TEntityCapabilities[];
+  pending_capabilities: TEntityCapabilities[];
   address: IEntityAddress;
   status: TEntityStatuses;
   error: IResourceError | null;
@@ -132,8 +135,38 @@ export interface IEntityListOpts {
   from_date?: string | null;
   page?: number | string | null;
   page_limit?: number | string | null;
+  page_cursor?: string | null;
   status?: string | null;
   type?: string | null;
+}
+
+export interface IEntityAnswer {
+  id: string,
+  text: string
+}
+
+export interface IEntityQuestion {
+  id: string,
+  text: string | null,
+  answers: IEntityAnswer[]
+}
+
+export interface IEntityQuestionResponse {
+  questions: IEntityQuestion[]
+}
+
+export interface IAnswerOpts {
+  question_id: string,
+  answer_id: string
+}
+
+export interface IEntityUpdateAuthOpts {
+  answers: IAnswerOpts[]
+}
+
+export interface IEntityUpdateAuthResponse {
+  questions: IEntityQuestion[],
+  cxn_id: string | null
 }
 
 
@@ -162,5 +195,17 @@ export default class Entity extends Resource<void> {
 
   async list(opts?: IEntityListOpts) {
     return super._list<IEntity>(opts);
+  }
+
+  async createAuthSession(id: string) {
+    return super._createAuthSession<IEntityQuestionResponse>(id);
+  }
+
+  async updateAuthSession(id: string, opts: IEntityUpdateAuthOpts) {
+    return super._updateAuthSession<IEntityUpdateAuthResponse, IEntityUpdateAuthOpts>(id, opts)
+  }
+
+  async refreshCapabilities(id: string) {
+    return super._refreshCapabilities<IEntity>(id);
   }
 };

--- a/src/resources/Payment/index.ts
+++ b/src/resources/Payment/index.ts
@@ -81,6 +81,7 @@ export interface IPaymentListOpts {
   from_date?: string | null;
   page?: number | string | null;
   page_limit?: number | string | null;
+  page_cursor?: string | null;
   status?: string | null;
   type?: string | null;
   source?: string | null;

--- a/test/resources/Element.tests.ts
+++ b/test/resources/Element.tests.ts
@@ -19,7 +19,7 @@ describe('Elements - core methods tests', () => {
         last_name: 'Doyle',
         dob: '1930-03-11',
         email: 'kevin.doyle@gmail.com',
-        phone: '+16505555555',
+        phone: '+15121231111',
       },
     });
   });

--- a/test/resources/Entity.tests.ts
+++ b/test/resources/Entity.tests.ts
@@ -4,7 +4,7 @@ import { IEntity, IEntityQuestionResponse } from '../../src/resources/Entity';
 
 should();
 
-const client = new MethodClient({ apiKey: 'process.env.TEST_CLIENT_KEY', env: Environments.dev });
+const client = new MethodClient({ apiKey: process.env.TEST_CLIENT_KEY, env: Environments.dev });
 
 describe('Entities - core methods tests', () => {
   let entities_create_response: IEntity | null = null;

--- a/test/resources/Entity.tests.ts
+++ b/test/resources/Entity.tests.ts
@@ -1,22 +1,29 @@
 import { should } from 'chai';
 import { MethodClient, Environments } from '../../src';
-import { IEntity } from '../../src/resources/Entity';
+import { IEntity, IEntityQuestionResponse } from '../../src/resources/Entity';
 
 should();
 
-const client = new MethodClient({ apiKey: process.env.TEST_CLIENT_KEY, env: Environments.dev });
+const client = new MethodClient({ apiKey: 'process.env.TEST_CLIENT_KEY', env: Environments.dev });
 
 describe('Entities - core methods tests', () => {
   let entities_create_response: IEntity | null = null;
   let entities_get_response: IEntity | null = null;
   let entities_update_response: IEntity | null = null;
   let entities_list_response: IEntity[] | null = null;
+  let entities_create_auth_session_response: IEntityQuestionResponse | null;
+  let entities_update_auth_session_response: IEntityQuestionResponse | null;
+  let entities_refresh_capabilities_response: IEntity | null;
 
   describe('entities.create', () => {
     it('should successfully create an entity.', async () => {
       entities_create_response = await client.entities.create({
         type: 'individual',
-        individual: {},
+        individual: {
+          first_name: 'Kevin',
+          last_name: 'Doyle',
+          phone: '+15121231111',
+        },
         metadata: {},
       });
 
@@ -43,7 +50,7 @@ describe('Entities - core methods tests', () => {
     });
   });
 
-  describe('entities.update', () => {
+  describe('entities.list', () => {
     it('should successfully list entities.', async () => {
       entities_list_response = await client.entities.list();
 
@@ -51,4 +58,43 @@ describe('Entities - core methods tests', () => {
       Array.isArray(entities_list_response).should.be.true;
     });
   });
+
+  describe('entities.create_auth_session', () => {
+    it('should successfully initiate an authenticated session for the entity', async () => {
+      entities_create_auth_session_response = await client.entities.createAuthSession(entities_create_response.id);
+
+      (entities_create_auth_session_response !== null).should.be.true
+    })
+  })
+
+  describe('entities.update_auth_session', () => {
+    it('should successfully provide answers to the security questions', async () => {
+      entities_update_auth_session_response = await client.entities.updateAuthSession(entities_create_response.id, {
+        answers: [
+          {
+            question_id: entities_create_auth_session_response.questions[0].id,
+            answer_id: entities_create_auth_session_response.questions[0].answers[0].id
+          },
+          {
+            question_id: entities_create_auth_session_response.questions[1].id,
+            answer_id: entities_create_auth_session_response.questions[1].answers[0].id
+          },
+          {
+            question_id: entities_create_auth_session_response.questions[2].id,
+            answer_id: entities_create_auth_session_response.questions[2].answers[0].id
+          }
+        ]
+      });
+
+      (entities_create_auth_session_response !== null).should.be.true
+    })
+  })
+
+  describe('entities.refresh_capabilities', () => {
+    it('should successfully refresh entity capabilities', async () => {
+      entities_refresh_capabilities_response = await client.entities.refreshCapabilities(entities_create_response.id);
+
+      (entities_refresh_capabilities_response !== null).should.be.true
+    })
+  })
 });

--- a/test/resources/Entity.tests.ts
+++ b/test/resources/Entity.tests.ts
@@ -19,11 +19,7 @@ describe('Entities - core methods tests', () => {
     it('should successfully create an entity.', async () => {
       entities_create_response = await client.entities.create({
         type: 'individual',
-        individual: {
-          first_name: 'Kevin',
-          last_name: 'Doyle',
-          phone: '+15121231111',
-        },
+        individual: {},
         metadata: {},
       });
 
@@ -43,7 +39,13 @@ describe('Entities - core methods tests', () => {
     it('should successfully update an entity.', async () => {
       entities_update_response = await client.entities.update(
         entities_get_response.id,
-        { individual: { first_name: 'Kevin', last_name: 'Doyle' } },
+        {
+          individual: {
+            first_name: 'Kevin',
+            last_name: 'Doyle',
+            phone: '+15121231111',
+          },
+        },
       );
 
       (entities_update_response !== null).should.be.true;

--- a/test/resources/Payment.tests.ts
+++ b/test/resources/Payment.tests.ts
@@ -26,7 +26,7 @@ describe('Payments - core methods tests', () => {
         last_name: 'Doyle',
         dob: '1930-03-11',
         email: 'kevin.doyle@gmail.com',
-        phone: '+16505555555',
+        phone: '+15121231111',
       },
     });
     source_1_response = await client.accounts.create({


### PR DESCRIPTION
**New routes:** 
Entity:  
- `POST /entities/:entityId/auth_session`
- `PUT /entities/:entityId/auth_session`
- `POST /entities/:entityId/refresh_capabilities`

**New types:**

Entities
- `available_capabilities: Array<Capability>`
- `pending_capabilities: Array<Capability>` 
- new capability: `data:retrieve`

Account
- `status` - new statuses (closed, processing)

All affected resources
- add `page_cursor` as parameter to list methods.

https://linear.app/methodfi/issue/MTHD-1587/update-the-following-octo-clients