### PR TITLE
Expose custom httpsAgent for Axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "method-node",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Node.js library for the Method API",
   "main": "dist/index.ts",
   "module": "dist/index.mjs",

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -53,6 +53,7 @@ export type TOnResponse = (event: IResponseEvent, axios_response: AxiosResponse)
 export interface IConfigurationOpts {
   apiKey: string;
   env: TEnvironments;
+  httpsAgent?: any;
   onRequest?: TOnRequest;
   onResponse?: TOnResponse;
 }
@@ -60,6 +61,7 @@ export interface IConfigurationOpts {
 export default class Configuration {
   baseURL: string;
   apiKey: string;
+  httpsAgent?: any;
   onResponse: TOnResponse | null;
   onRequest: TOnRequest | null;
 
@@ -68,6 +70,7 @@ export default class Configuration {
 
     this.baseURL = `https://${opts.env}.methodfi.com`;
     this.apiKey = opts.apiKey;
+    this.httpsAgent = opts.httpsAgent || null;
     this.onRequest = opts.onRequest || null;
     this.onResponse = opts.onResponse || null;
   }

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -28,6 +28,7 @@ export default class Resource extends ExtensibleFunction {
     this.client = axios.create({
       baseURL: config.baseURL,
       headers: { Authorization: `Bearer ${config.apiKey}`, 'User-Agent': this.getDefaultUserAgent() },
+      httpsAgent: config.httpsAgent,
     });
 
     this.configureRequestInterceptors();


### PR DESCRIPTION
Customers should be able to pass in a custom httpsAgent under `httpsAgent`
```javascript
import { Method, Environments } from 'method-node';
import HttpsProxyAgent from 'https-proxy-agent';

const customAgent = new HttpsProxyAgent('url');

const method = new Method({
  apiKey: '<API_KEY>',
  env: Environments.dev,
  httpsAgent: customAgent,
});
```