### PR TITLE
Fix tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "method-node",
-  "version": "0.3.10",
+  "version": "0.3.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "method-node",
-      "version": "0.3.10",
+      "version": "0.3.18",
       "license": "ISC",
       "dependencies": {
         "axios": "^0.26.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "./node_modules/.bin/rollup -c",
     "dev": "./node_modules/.bin/rollup -c -w",
     "pretest": "./node_modules/.bin/tsc -p tsconfig-test.json",
-    "test": "./node_modules/.bin/mocha --exit --timeout 100000 ./test-dist/test/index.js"
+    "test": "NODE_ENV=TEST ./node_modules/.bin/mocha --exit --timeout 100000 ./test-dist/test/index.js"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './method';
+export {Method as MethodClient} from './method';
 export * from './errors';
 export * from './configuration';
 export * from './resources/Account';

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -36,7 +36,9 @@ export default class Resource extends ExtensibleFunction {
   }
 
   private getDefaultUserAgent(): string {
-    return `Method-Node/v${require('../package.json').version}`;
+    return `Method-Node/v${require(
+      process.env.NODE_ENV === 'TEST' ? '../../package.json' : '../package.json'
+    ).version}`;
   }
 
   private configureRequestInterceptors(): void {

--- a/test/resources/Merchant.tests.ts
+++ b/test/resources/Merchant.tests.ts
@@ -11,6 +11,7 @@ describe('Merchants - core methods tests', () => {
   let merchants_list_response: IMerchant[] | null = null;
   const amex_mch_id = 'mch_3';
   const amex_provider_id_plaid = 'ins_10';
+  const expected_amex_mch_id = 'mch_300485';
 
   describe('merchants.get', () => {
     it('should successfully get a merchant.', async () => {
@@ -28,7 +29,7 @@ describe('Merchants - core methods tests', () => {
       Array.isArray(merchants_list_response).should.be.true;
 
       merchants_list_response.length.should.equal(1);
-      merchants_list_response[0].mch_id.should.equal(amex_mch_id);
+      merchants_list_response[0].mch_id.should.equal(expected_amex_mch_id);
     });
   });
 });


### PR DESCRIPTION
Distinguish `package.json` relative path for test-dist.
Export `Method as MethodClient` for tests.
Update expected listed merchant id.

This doesn't address the `Doppler Error: Invalid Auth token` in the GitHub Actions test workflow, but I am now able to run tests locally with:
```
$ TEST_CLIENT_KEY=<MY-DEV-API-KEY> npm test
```