### PR TITLE
allows for either string or enroll payload when creating subscriptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "method-node",
-  "version": "1.1.14",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "method-node",
-      "version": "1.1.14",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "method-node",
-  "version": "1.1.14",
+  "version": "1.2.0",
   "description": "Node.js library for the Method API",
   "main": "dist/index.ts",
   "module": "dist/index.mjs",

--- a/src/resources/Entity/Subscriptions.ts
+++ b/src/resources/Entity/Subscriptions.ts
@@ -43,7 +43,12 @@ export default class EntitySubscriptions extends Resource {
    * @returns Returns a map of Subscription name to either Subscription object or Error.
    */
 
-  async create(opts: IEntitySubscriptionCreateOpts, requestConfig?: IRequestConfig) {
+  async create(opts: IEntitySubscriptionCreateOpts | TEntitySubscriptionNames, requestConfig?: IRequestConfig) {
+    if (typeof opts === 'string') {
+      opts = {
+        enroll: opts as TEntitySubscriptionNames,
+      };
+    }
     return super._create<IResponse<IEntitySubscription>, IEntitySubscriptionCreateOpts>(opts, requestConfig);
   }
 

--- a/test/resources/Entity.tests.ts
+++ b/test/resources/Entity.tests.ts
@@ -966,9 +966,7 @@ describe('Entities - core methods tests', () => {
     it('should create a connect subscription for an entity', async () => {
       entities_create_connect_subscription_response = await client
         .entities(entities_create_response.id)
-        .subscriptions.create({
-          enroll: 'connect'
-        });
+        .subscriptions.create('connect');
 
       const expect_connect_results: IEntitySubscription = {
         id: entities_create_connect_subscription_response.id,
@@ -989,9 +987,7 @@ describe('Entities - core methods tests', () => {
     it('should create a credit_score subscription for an entity', async () => {
       entities_create_credit_score_subscription_response = await client
         .entities(entities_create_response.id)
-        .subscriptions.create({
-          enroll: 'credit_score'
-        });
+        .subscriptions.create('credit_score');
 
       const expect_credit_score_results: IEntitySubscription = {
         id: entities_create_credit_score_subscription_response.id,


### PR DESCRIPTION
Fixes breaking change issue to allow for either a string or the full payload when creating entity subscriptions.