### PR TITLE
adds OpenAPI spec generation scripts

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,2 @@
+extends:
+  - spectral:oas

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,9117 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Method API",
+    "version": "2025-07-04",
+    "description": "Method Financial API - Node SDK Generated OpenAPI Specification",
+    "contact": {
+      "name": "Method Financial",
+      "url": "https://methodfi.com",
+      "email": "support@methodfi.com"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://production.methodfi.com",
+      "description": "Production"
+    },
+    {
+      "url": "https://sandbox.methodfi.com",
+      "description": "Sandbox"
+    },
+    {
+      "url": "https://dev.methodfi.com",
+      "description": "Development"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Entities",
+      "description": "Entity management endpoints"
+    },
+    {
+      "name": "Entities - Connect",
+      "description": "Entity connection endpoints"
+    },
+    {
+      "name": "Entities - Credit Scores",
+      "description": "Entity credit score endpoints"
+    },
+    {
+      "name": "Entities - Identities",
+      "description": "Entity identity endpoints"
+    },
+    {
+      "name": "Entities - Attributes",
+      "description": "Entity attribute endpoints"
+    },
+    {
+      "name": "Entities - Vehicles",
+      "description": "Entity vehicle endpoints"
+    },
+    {
+      "name": "Entities - Products",
+      "description": "Entity product endpoints"
+    },
+    {
+      "name": "Entities - Subscriptions",
+      "description": "Entity subscription endpoints"
+    },
+    {
+      "name": "Entities - Verification Sessions",
+      "description": "Entity verification session endpoints"
+    },
+    {
+      "name": "Accounts",
+      "description": "Account management endpoints"
+    },
+    {
+      "name": "Accounts - Balances",
+      "description": "Account balance endpoints"
+    },
+    {
+      "name": "Accounts - CardBrands",
+      "description": "Account card brand endpoints"
+    },
+    {
+      "name": "Accounts - Payoffs",
+      "description": "Account payoff endpoints"
+    },
+    {
+      "name": "Accounts - Sensitives",
+      "description": "Account sensitive data endpoints"
+    },
+    {
+      "name": "Accounts - Transactions",
+      "description": "Account transaction endpoints"
+    },
+    {
+      "name": "Accounts - Updates",
+      "description": "Account update endpoints"
+    },
+    {
+      "name": "Accounts - Attributess",
+      "description": "Account attribute endpoints"
+    },
+    {
+      "name": "Accounts - PaymentInstruments",
+      "description": "Account payment instrument endpoints"
+    },
+    {
+      "name": "Accounts - Subscriptions",
+      "description": "Account subscription endpoints"
+    },
+    {
+      "name": "Accounts - Products",
+      "description": "Account product endpoints"
+    },
+    {
+      "name": "Accounts - Verification Sessions",
+      "description": "Account verification session endpoints"
+    },
+    {
+      "name": "Payments",
+      "description": "Payment management endpoints"
+    },
+    {
+      "name": "Payments - Reversals",
+      "description": "Payment reversal endpoints"
+    },
+    {
+      "name": "Webhooks",
+      "description": "Webhook management endpoints"
+    },
+    {
+      "name": "Reports",
+      "description": "Report management endpoints"
+    },
+    {
+      "name": "Merchants",
+      "description": "Merchant lookup endpoints"
+    },
+    {
+      "name": "Events",
+      "description": "Event retrieval endpoints"
+    },
+    {
+      "name": "Elements",
+      "description": "Element token endpoints"
+    },
+    {
+      "name": "Opal",
+      "description": "Opal token endpoints"
+    },
+    {
+      "name": "Simulate",
+      "description": "Simulation endpoints for testing"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "paths": {
+    "/entities": {
+      "get": {
+        "operationId": "listEntities",
+        "summary": "List all entities",
+        "description": "List all entities. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Entity"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createEntity",
+        "summary": "Create a new entity",
+        "description": "Create a new entity. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Entity"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{ent_id}": {
+      "get": {
+        "operationId": "retrieveEntity",
+        "summary": "Retrieve an entity",
+        "description": "Retrieve an entity. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Entity"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "connect",
+                  "credit_score",
+                  "attribute",
+                  "vehicle",
+                  "identity_latest_verification_session",
+                  "phone_latest_verification_session"
+                ]
+              }
+            },
+            "description": "Fields to expand in the response. Can specify multiple values.",
+            "style": "form",
+            "explode": true
+          }
+        ]
+      },
+      "put": {
+        "operationId": "updateEntity",
+        "summary": "Update an entity",
+        "description": "Update an entity. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Entity"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityUpdateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{ent_id}/consent": {
+      "post": {
+        "operationId": "withdrawEntityConsent",
+        "summary": "Withdraw entity consent",
+        "description": "Withdraw entity consent. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Entity"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityWithdrawConsentRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{ent_id}/connect": {
+      "get": {
+        "operationId": "listEntityConnect",
+        "summary": "List entity connect records",
+        "description": "List entity connect records. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Connect"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EntityConnect"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createEntityConnect",
+        "summary": "Create entity connect",
+        "description": "Create entity connect. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Connect"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityConnect"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityConnectCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{ent_id}/connect/{cxn_id}": {
+      "get": {
+        "operationId": "retrieveEntityConnect",
+        "summary": "Retrieve entity connect",
+        "description": "Retrieve entity connect. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Connect"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityConnect"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cxn_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/entities/{ent_id}/credit_scores": {
+      "get": {
+        "operationId": "listEntityCreditScores",
+        "summary": "List entity credit scores",
+        "description": "List entity credit scores. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Credit Scores"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EntityCreditScores"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createEntityCreditScores",
+        "summary": "Create entity credit scores request",
+        "description": "Create entity credit scores request. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Credit Scores"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityCreditScores"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    },
+    "/entities/{ent_id}/credit_scores/{crs_id}": {
+      "get": {
+        "operationId": "retrieveEntityCreditScores",
+        "summary": "Retrieve entity credit scores",
+        "description": "Retrieve entity credit scores. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Credit Scores"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityCreditScores"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "crs_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/entities/{ent_id}/identities": {
+      "get": {
+        "operationId": "listEntityIdentities",
+        "summary": "List entity identities",
+        "description": "List entity identities. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Identities"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EntityIdentity"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createEntityIdentity",
+        "summary": "Create entity identity request",
+        "description": "Create entity identity request. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Identities"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityIdentity"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    },
+    "/entities/{ent_id}/identities/{idn_id}": {
+      "get": {
+        "operationId": "retrieveEntityIdentity",
+        "summary": "Retrieve entity identity",
+        "description": "Retrieve entity identity. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Identities"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityIdentity"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "idn_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/entities/{ent_id}/attributes": {
+      "get": {
+        "operationId": "listEntityAttributes",
+        "summary": "List entity attributes",
+        "description": "List entity attributes. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Attributes"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EntityAttributes"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createEntityAttributes",
+        "summary": "Create entity attributes request",
+        "description": "Create entity attributes request. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Attributes"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityAttributes"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityAttributesCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{ent_id}/attributes/{atr_id}": {
+      "get": {
+        "operationId": "retrieveEntityAttributes",
+        "summary": "Retrieve entity attributes",
+        "description": "Retrieve entity attributes. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Attributes"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityAttributes"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "atr_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/entities/{ent_id}/vehicles": {
+      "get": {
+        "operationId": "listEntityVehicles",
+        "summary": "List entity vehicles",
+        "description": "List entity vehicles. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Vehicles"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EntityVehicles"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createEntityVehicles",
+        "summary": "Create entity vehicles request",
+        "description": "Create entity vehicles request. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Vehicles"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityVehicles"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    },
+    "/entities/{ent_id}/vehicles/{vhl_id}": {
+      "get": {
+        "operationId": "retrieveEntityVehicles",
+        "summary": "Retrieve entity vehicles",
+        "description": "Retrieve entity vehicles. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Vehicles"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityVehicles"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "vhl_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/entities/{ent_id}/products": {
+      "get": {
+        "operationId": "listEntityProducts",
+        "summary": "List entity products",
+        "description": "List entity products. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Products"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityProductListResponse"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/entities/{ent_id}/subscriptions": {
+      "get": {
+        "operationId": "listEntitySubscriptions",
+        "summary": "List entity subscriptions",
+        "description": "List entity subscriptions. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Subscriptions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EntitySubscription"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createEntitySubscription",
+        "summary": "Create entity subscription",
+        "description": "Create entity subscription. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Subscriptions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntitySubscription"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntitySubscriptionCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{ent_id}/subscriptions/{sub_id}": {
+      "get": {
+        "operationId": "retrieveEntitySubscription",
+        "summary": "Retrieve entity subscription",
+        "description": "Retrieve entity subscription. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Subscriptions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntitySubscription"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sub_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteEntitySubscription",
+        "summary": "Delete entity subscription",
+        "description": "Delete entity subscription. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Subscriptions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntitySubscription"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sub_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/entities/{ent_id}/verification_sessions": {
+      "get": {
+        "operationId": "listEntityVerificationSessions",
+        "summary": "List entity verification sessions",
+        "description": "List entity verification sessions. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Verification Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EntityVerificationSession"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createEntityVerificationSession",
+        "summary": "Create entity verification session",
+        "description": "Create entity verification session. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Verification Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityVerificationSession"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityVerificationSessionCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{ent_id}/verification_sessions/{evf_id}": {
+      "get": {
+        "operationId": "retrieveEntityVerificationSession",
+        "summary": "Retrieve entity verification session",
+        "description": "Retrieve entity verification session. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Verification Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityVerificationSession"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "evf_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "put": {
+        "operationId": "updateEntityVerificationSession",
+        "summary": "Update entity verification session",
+        "description": "Update entity verification session. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Entities - Verification Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityVerificationSession"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "evf_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityVerificationSessionUpdateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/accounts": {
+      "get": {
+        "operationId": "listAccounts",
+        "summary": "List all accounts",
+        "description": "List all accounts. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Account"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "holder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "payment",
+                  "balance",
+                  "sensitive",
+                  "card_brand",
+                  "payoff",
+                  "update",
+                  "attribute",
+                  "transactions",
+                  "payment_instrument",
+                  "latest_verification_session"
+                ]
+              }
+            },
+            "description": "Fields to expand in the response. Can specify multiple values.",
+            "style": "form",
+            "explode": true
+          },
+          {
+            "name": "liability.mch_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "liability.type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "liability.ownership",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createAccount",
+        "summary": "Create a new account",
+        "description": "Create a new account. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/accounts/{acc_id}": {
+      "get": {
+        "operationId": "retrieveAccount",
+        "summary": "Retrieve an account",
+        "description": "Retrieve an account. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "expand",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "payment",
+                  "balance",
+                  "sensitive",
+                  "card_brand",
+                  "payoff",
+                  "update",
+                  "attribute",
+                  "transactions",
+                  "payment_instrument",
+                  "latest_verification_session"
+                ]
+              }
+            },
+            "description": "Fields to expand in the response. Can specify multiple values.",
+            "style": "form",
+            "explode": true
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/consent": {
+      "post": {
+        "operationId": "withdrawAccountConsent",
+        "summary": "Withdraw account consent",
+        "description": "Withdraw account consent. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountWithdrawConsentRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/accounts/{acc_id}/balances": {
+      "get": {
+        "operationId": "listAccountBalances",
+        "summary": "List account balances",
+        "description": "List account balances. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Balances"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountBalance"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createAccountBalance",
+        "summary": "Create account balance",
+        "description": "Create account balance. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Balances"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountBalance"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/balances/{balance_id}": {
+      "get": {
+        "operationId": "retrieveAccountBalance",
+        "summary": "Retrieve account balance",
+        "description": "Retrieve account balance. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Balances"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountBalance"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "balance_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/card_brands": {
+      "get": {
+        "operationId": "listAccountCardBrands",
+        "summary": "List account card_brands",
+        "description": "List account card_brands. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - CardBrands"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountCardBrand"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createAccountCardBrand",
+        "summary": "Create account card_brand",
+        "description": "Create account card_brand. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - CardBrands"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountCardBrand"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/card_brands/{card_brand_id}": {
+      "get": {
+        "operationId": "retrieveAccountCardBrand",
+        "summary": "Retrieve account card_brand",
+        "description": "Retrieve account card_brand. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - CardBrands"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountCardBrand"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "card_brand_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/payoffs": {
+      "get": {
+        "operationId": "listAccountPayoffs",
+        "summary": "List account payoffs",
+        "description": "List account payoffs. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Payoffs"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountPayoff"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createAccountPayoff",
+        "summary": "Create account payoff",
+        "description": "Create account payoff. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Payoffs"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountPayoff"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/payoffs/{payoff_id}": {
+      "get": {
+        "operationId": "retrieveAccountPayoff",
+        "summary": "Retrieve account payoff",
+        "description": "Retrieve account payoff. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Payoffs"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountPayoff"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "payoff_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/sensitive": {
+      "get": {
+        "operationId": "listAccountSensitives",
+        "summary": "List account sensitive",
+        "description": "List account sensitive. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Sensitives"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountSensitive"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createAccountSensitive",
+        "summary": "Create account sensitiv",
+        "description": "Create account sensitiv. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Sensitives"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountSensitive"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountSensitiveCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/accounts/{acc_id}/sensitive/{sensitiv_id}": {
+      "get": {
+        "operationId": "retrieveAccountSensitive",
+        "summary": "Retrieve account sensitiv",
+        "description": "Retrieve account sensitiv. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Sensitives"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountSensitive"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sensitiv_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/transactions": {
+      "get": {
+        "operationId": "listAccountTransactions",
+        "summary": "List account transactions",
+        "description": "List account transactions. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Transactions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountTransaction"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/transactions/{transaction_id}": {
+      "get": {
+        "operationId": "retrieveAccountTransaction",
+        "summary": "Retrieve account transaction",
+        "description": "Retrieve account transaction. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Transactions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountTransaction"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "transaction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/updates": {
+      "get": {
+        "operationId": "listAccountUpdates",
+        "summary": "List account updates",
+        "description": "List account updates. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Updates"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountUpdate"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createAccountUpdate",
+        "summary": "Create account update",
+        "description": "Create account update. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Updates"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountUpdate"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/updates/{update_id}": {
+      "get": {
+        "operationId": "retrieveAccountUpdate",
+        "summary": "Retrieve account update",
+        "description": "Retrieve account update. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Updates"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountUpdate"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "update_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/attributes": {
+      "get": {
+        "operationId": "listAccountAttributess",
+        "summary": "List account attributes",
+        "description": "List account attributes. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Attributess"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountAttributes"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createAccountAttributes",
+        "summary": "Create account attribute",
+        "description": "Create account attribute. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Attributess"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountAttributes"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/attributes/{attribute_id}": {
+      "get": {
+        "operationId": "retrieveAccountAttributes",
+        "summary": "Retrieve account attribute",
+        "description": "Retrieve account attribute. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Attributess"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountAttributes"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "attribute_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/payment_instruments": {
+      "get": {
+        "operationId": "listAccountPaymentInstruments",
+        "summary": "List account payment_instruments",
+        "description": "List account payment_instruments. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - PaymentInstruments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountPaymentInstrument"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createAccountPaymentInstrument",
+        "summary": "Create account payment_instrument",
+        "description": "Create account payment_instrument. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - PaymentInstruments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountPaymentInstrument"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountPaymentInstrumentCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/accounts/{acc_id}/payment_instruments/{payment_instrument_id}": {
+      "get": {
+        "operationId": "retrieveAccountPaymentInstrument",
+        "summary": "Retrieve account payment_instrument",
+        "description": "Retrieve account payment_instrument. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - PaymentInstruments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountPaymentInstrument"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "payment_instrument_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/subscriptions": {
+      "get": {
+        "operationId": "listAccountSubscriptions",
+        "summary": "List account subscriptions",
+        "description": "List account subscriptions. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Subscriptions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountSubscription"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createAccountSubscription",
+        "summary": "Create account subscription",
+        "description": "Create account subscription. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Subscriptions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountSubscription"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountSubscriptionCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/accounts/{acc_id}/subscriptions/{sub_id}": {
+      "get": {
+        "operationId": "retrieveAccountSubscription",
+        "summary": "Retrieve account subscription",
+        "description": "Retrieve account subscription. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Subscriptions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountSubscription"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sub_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deleteAccountSubscription",
+        "summary": "Delete account subscription",
+        "description": "Delete account subscription. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Subscriptions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountSubscription"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sub_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/products": {
+      "get": {
+        "operationId": "listAccountProducts",
+        "summary": "List account products",
+        "description": "List account products. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Products"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountProduct"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/accounts/{acc_id}/verification_sessions": {
+      "get": {
+        "operationId": "listAccountVerificationSessions",
+        "summary": "List account verification sessions",
+        "description": "List account verification sessions. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Verification Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AccountVerificationSession"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createAccountVerificationSession",
+        "summary": "Create account verification session",
+        "description": "Create account verification session. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Verification Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountVerificationSession"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountVerificationSessionCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/accounts/{acc_id}/verification_sessions/{avf_id}": {
+      "get": {
+        "operationId": "retrieveAccountVerificationSession",
+        "summary": "Retrieve account verification session",
+        "description": "Retrieve account verification session. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Verification Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountVerificationSession"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "avf_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "put": {
+        "operationId": "updateAccountVerificationSession",
+        "summary": "Update account verification session",
+        "description": "Update account verification session. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Accounts - Verification Sessions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountVerificationSession"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "avf_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountVerificationSessionUpdateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments": {
+      "get": {
+        "operationId": "listPayments",
+        "summary": "List all payments",
+        "description": "List all payments. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Payments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Payment"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "destination",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "reversal_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "source_holder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "destination_holder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "acc_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "holder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "operationId": "createPayment",
+        "summary": "Create a new payment",
+        "description": "Create a new payment. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Payments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Payment"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/{pmt_id}": {
+      "get": {
+        "operationId": "retrievePayment",
+        "summary": "Retrieve a payment",
+        "description": "Retrieve a payment. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Payments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Payment"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pmt_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "deletePayment",
+        "summary": "Cancel a payment",
+        "description": "Cancel a payment. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Payments"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Payment"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pmt_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/payments/{pmt_id}/reversals": {
+      "get": {
+        "operationId": "listPaymentReversals",
+        "summary": "List payment reversals",
+        "description": "List payment reversals. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Payments - Reversals"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Reversal"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pmt_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/payments/{pmt_id}/reversals/{rvs_id}": {
+      "get": {
+        "operationId": "retrievePaymentReversal",
+        "summary": "Retrieve payment reversal",
+        "description": "Retrieve payment reversal. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Payments - Reversals"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reversal"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pmt_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rvs_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "put": {
+        "operationId": "updatePaymentReversal",
+        "summary": "Update payment reversal",
+        "description": "Update payment reversal. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Payments - Reversals"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Reversal"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pmt_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rvs_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReversalUpdateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhooks": {
+      "get": {
+        "operationId": "listWebhooks",
+        "summary": "List all webhooks",
+        "description": "List all webhooks. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Webhooks"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Webhook"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createWebhook",
+        "summary": "Create a new webhook",
+        "description": "Create a new webhook. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Webhooks"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Webhook"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/webhooks/{whk_id}": {
+      "get": {
+        "operationId": "retrieveWebhook",
+        "summary": "Retrieve a webhook",
+        "description": "Retrieve a webhook. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Webhooks"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Webhook"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "whk_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "patch": {
+        "operationId": "updateWebhook",
+        "summary": "Update a webhook",
+        "description": "Update a webhook. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Webhooks"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Webhook"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "whk_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookUpdateRequest"
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteWebhook",
+        "summary": "Delete a webhook",
+        "description": "Delete a webhook. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Webhooks"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "whk_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/reports": {
+      "post": {
+        "operationId": "createReport",
+        "summary": "Create a new report",
+        "description": "Create a new report. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Reports"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Report"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReportCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{rpt_id}": {
+      "get": {
+        "operationId": "retrieveReport",
+        "summary": "Retrieve a report",
+        "description": "Retrieve a report. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Reports"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Report"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "rpt_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/reports/{rpt_id}/download": {
+      "get": {
+        "operationId": "downloadReport",
+        "summary": "Download a report",
+        "description": "Download a report as CSV",
+        "tags": [
+          "Reports"
+        ],
+        "parameters": [
+          {
+            "name": "rpt_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Report CSV data",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/merchants": {
+      "get": {
+        "operationId": "listMerchants",
+        "summary": "List all merchants",
+        "description": "List all merchants. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Merchants"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Merchant"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "creditor_name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider_id.plaid",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider_id.mx",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider_id.finicity",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider_id.dpp",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/merchants/{mch_id}": {
+      "get": {
+        "operationId": "retrieveMerchant",
+        "summary": "Retrieve a merchant",
+        "description": "Retrieve a merchant. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Merchants"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Merchant"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "mch_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/events": {
+      "get": {
+        "operationId": "listEvents",
+        "summary": "List all events",
+        "description": "List all events. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Events"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              },
+              "pagination-page": {
+                "$ref": "#/components/headers/PaginationPage"
+              },
+              "pagination-page-count": {
+                "$ref": "#/components/headers/PaginationPageCount"
+              },
+              "pagination-page-limit": {
+                "$ref": "#/components/headers/PaginationPageLimit"
+              },
+              "pagination-total-count": {
+                "$ref": "#/components/headers/PaginationTotalCount"
+              },
+              "pagination-page-cursor-next": {
+                "$ref": "#/components/headers/PaginationPageCursorNext"
+              },
+              "pagination-page-cursor-prev": {
+                "$ref": "#/components/headers/PaginationPageCursorPrev"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "from_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to_date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page_cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "resource_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "resource_type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/events/{evt_id}": {
+      "get": {
+        "operationId": "retrieveEvent",
+        "summary": "Retrieve an event",
+        "description": "Retrieve an event. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Events"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "evt_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/elements/token": {
+      "post": {
+        "operationId": "createElementToken",
+        "summary": "Create an element token",
+        "description": "Create an element token. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Elements"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ElementToken"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ElementTokenCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/elements/token/{pk_elem_id}/results": {
+      "get": {
+        "operationId": "retrieveElementResults",
+        "summary": "Retrieve element results",
+        "description": "Retrieve element results. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Elements"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ElementResults"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pk_elem_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
+    "/opal/token": {
+      "post": {
+        "operationId": "createOpalToken",
+        "summary": "Create an opal token",
+        "description": "Create an opal token. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Opal"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpalToken"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpalTokenCreateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/simulate/payments/{pmt_id}": {
+      "post": {
+        "operationId": "simulatePaymentUpdate",
+        "summary": "Simulate payment status update",
+        "description": "Simulate payment status update. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Simulate"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Payment"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "pmt_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimulatePaymentUpdateRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/simulate/accounts/{acc_id}/transactions": {
+      "post": {
+        "operationId": "simulateAccountTransaction",
+        "summary": "Simulate account transaction",
+        "description": "Simulate account transaction. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Simulate"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccountTransaction"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "acc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    },
+    "/simulate/entities/{ent_id}/connect": {
+      "post": {
+        "operationId": "simulateEntityConnect",
+        "summary": "Simulate entity connect",
+        "description": "Simulate entity connect. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Simulate"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityConnect"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimulateEntityConnectRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/simulate/entities/{ent_id}/credit_scores/{crs_id}": {
+      "post": {
+        "operationId": "simulateEntityCreditScores",
+        "summary": "Simulate entity credit scores",
+        "description": "Simulate entity credit scores. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Simulate"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityCreditScores"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "crs_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    },
+    "/simulate/entities/{ent_id}/attributes/{atr_id}": {
+      "post": {
+        "operationId": "simulateEntityAttributes",
+        "summary": "Simulate entity attributes",
+        "description": "Simulate entity attributes. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Simulate"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityAttributes"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "ent_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "atr_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SimulateEntityAttributesRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/simulate/events": {
+      "post": {
+        "operationId": "simulateEvent",
+        "summary": "Simulate an event",
+        "description": "Simulate an event. See https://docs.methodfi.com for more details.",
+        "tags": [
+          "Simulate"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "headers": {
+              "idem-request-id": {
+                "$ref": "#/components/headers/IdemRequestId"
+              },
+              "idem-status": {
+                "$ref": "#/components/headers/IdemStatus"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details."
+          },
+          {
+            "name": "Prefer",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "respond-async",
+                "respond-sync"
+              ]
+            },
+            "description": "Control response behavior. Use \"respond-async\" for long-running operations to get immediate response with status=pending."
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ResourceError": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "code": {
+            "type": "integer"
+          },
+          "sub_type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "ResourceStatus": {
+        "type": "string",
+        "enum": [
+          "completed",
+          "in_progress",
+          "pending",
+          "failed"
+        ]
+      },
+      "EntityType": {
+        "type": "string",
+        "enum": [
+          "individual",
+          "corporation"
+        ]
+      },
+      "EntityStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "incomplete",
+          "disabled"
+        ]
+      },
+      "EntityAddress": {
+        "type": "object",
+        "properties": {
+          "line1": {
+            "type": "string",
+            "nullable": true
+          },
+          "line2": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "state": {
+            "type": "string",
+            "nullable": true
+          },
+          "zip": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "EntityIndividual": {
+        "type": "object",
+        "properties": {
+          "first_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "last_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "dob": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssn": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssn_4": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "EntityCorporationOwner": {
+        "type": "object",
+        "properties": {
+          "first_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "last_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "dob": {
+            "type": "string",
+            "nullable": true
+          },
+          "address": {
+            "$ref": "#/components/schemas/EntityAddress"
+          }
+        }
+      },
+      "EntityCorporation": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "dba": {
+            "type": "string",
+            "nullable": true
+          },
+          "ein": {
+            "type": "string",
+            "nullable": true
+          },
+          "owners": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityCorporationOwner"
+            }
+          }
+        }
+      },
+      "Entity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntityType"
+              }
+            ],
+            "nullable": true
+          },
+          "individual": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntityIndividual"
+              }
+            ],
+            "nullable": true
+          },
+          "corporation": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntityCorporation"
+              }
+            ],
+            "nullable": true
+          },
+          "address": {
+            "$ref": "#/components/schemas/EntityAddress"
+          },
+          "status": {
+            "$ref": "#/components/schemas/EntityStatus"
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true
+          },
+          "products": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "restricted_products": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subscriptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "available_subscriptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "restricted_subscriptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "verification": {
+            "type": "object",
+            "nullable": true
+          },
+          "connect": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/EntityConnect"
+              }
+            ],
+            "nullable": true
+          },
+          "credit_score": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/EntityCreditScores"
+              }
+            ],
+            "nullable": true
+          },
+          "attribute": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/EntityAttributes"
+              }
+            ],
+            "nullable": true
+          },
+          "vehicle": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/EntityVehicles"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "EntityIndividualCreateRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "individual"
+            ]
+          },
+          "individual": {
+            "$ref": "#/components/schemas/EntityIndividual"
+          },
+          "address": {
+            "$ref": "#/components/schemas/EntityAddress"
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type",
+          "individual"
+        ]
+      },
+      "EntityCorporationCreateRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "corporation"
+            ]
+          },
+          "corporation": {
+            "$ref": "#/components/schemas/EntityCorporation"
+          },
+          "address": {
+            "$ref": "#/components/schemas/EntityAddress"
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true
+          }
+        },
+        "required": [
+          "type",
+          "corporation"
+        ]
+      },
+      "EntityCreateRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/EntityIndividualCreateRequest"
+          },
+          {
+            "$ref": "#/components/schemas/EntityCorporationCreateRequest"
+          }
+        ]
+      },
+      "EntityUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "$ref": "#/components/schemas/EntityAddress"
+          },
+          "corporation": {
+            "$ref": "#/components/schemas/EntityCorporation"
+          },
+          "individual": {
+            "$ref": "#/components/schemas/EntityIndividual"
+          }
+        }
+      },
+      "EntityConnect": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "accounts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "requested_products": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "requested_subscriptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "entity_id",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "EntityConnectCreateRequest": {
+        "type": "object",
+        "properties": {
+          "products": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subscriptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "CreditScoreModel": {
+        "type": "string",
+        "enum": [
+          "vantage_4",
+          "vantage_3"
+        ]
+      },
+      "CreditReportBureau": {
+        "type": "string",
+        "enum": [
+          "experian",
+          "equifax",
+          "transunion"
+        ]
+      },
+      "EntityCreditScoreFactor": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "EntityCreditScoreItem": {
+        "type": "object",
+        "properties": {
+          "score": {
+            "type": "integer"
+          },
+          "source": {
+            "$ref": "#/components/schemas/CreditReportBureau"
+          },
+          "model": {
+            "$ref": "#/components/schemas/CreditScoreModel"
+          },
+          "factors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityCreditScoreFactor"
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "EntityCreditScores": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "scores": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityCreditScoreItem"
+            },
+            "nullable": true
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "entity_id",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "EntityIdentityType": {
+        "type": "object",
+        "properties": {
+          "first_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "last_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "nullable": true
+          },
+          "dob": {
+            "type": "string",
+            "nullable": true
+          },
+          "address": {
+            "type": "object",
+            "nullable": true
+          },
+          "ssn": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "EntityIdentity": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "identities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityIdentityType"
+            }
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "entity_id",
+          "status",
+          "identities",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "CreditHealthAttributeRating": {
+        "type": "string",
+        "enum": [
+          "excellent",
+          "good",
+          "fair",
+          "needs_work"
+        ]
+      },
+      "CreditHealthAttribute": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "number"
+          },
+          "rating": {
+            "$ref": "#/components/schemas/CreditHealthAttributeRating"
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true
+          }
+        }
+      },
+      "EntityAttributesType": {
+        "type": "object",
+        "properties": {
+          "credit_health_credit_card_usage": {
+            "$ref": "#/components/schemas/CreditHealthAttribute"
+          },
+          "credit_health_derogatory_marks": {
+            "$ref": "#/components/schemas/CreditHealthAttribute"
+          },
+          "credit_health_hard_inquiries": {
+            "$ref": "#/components/schemas/CreditHealthAttribute"
+          },
+          "credit_health_soft_inquiries": {
+            "$ref": "#/components/schemas/CreditHealthAttribute"
+          },
+          "credit_health_total_accounts": {
+            "$ref": "#/components/schemas/CreditHealthAttribute"
+          },
+          "credit_health_credit_age": {
+            "$ref": "#/components/schemas/CreditHealthAttribute"
+          },
+          "credit_health_payment_history": {
+            "$ref": "#/components/schemas/CreditHealthAttribute"
+          },
+          "credit_health_open_accounts": {
+            "$ref": "#/components/schemas/CreditHealthAttribute"
+          },
+          "credit_health_entity_delinquent": {
+            "$ref": "#/components/schemas/CreditHealthAttribute"
+          }
+        }
+      },
+      "EntityAttributes": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "attributes": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EntityAttributesType"
+              }
+            ],
+            "nullable": true
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "entity_id",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "EntityAttributesCreateRequest": {
+        "type": "object",
+        "properties": {
+          "attributes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "credit_health_credit_card_usage",
+                "credit_health_derogatory_marks",
+                "credit_health_hard_inquiries",
+                "credit_health_soft_inquiries",
+                "credit_health_total_accounts",
+                "credit_health_credit_age",
+                "credit_health_payment_history",
+                "credit_health_open_accounts",
+                "credit_health_entity_delinquent"
+              ]
+            }
+          }
+        },
+        "required": [
+          "attributes"
+        ]
+      },
+      "EntityVehicleType": {
+        "type": "object",
+        "properties": {
+          "vin": {
+            "type": "string",
+            "nullable": true
+          },
+          "year": {
+            "type": "string",
+            "nullable": true
+          },
+          "make": {
+            "type": "string",
+            "nullable": true
+          },
+          "model": {
+            "type": "string",
+            "nullable": true
+          },
+          "series": {
+            "type": "string",
+            "nullable": true
+          },
+          "major_color": {
+            "type": "string",
+            "nullable": true
+          },
+          "style": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "EntityVehicles": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "vehicles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityVehicleType"
+            },
+            "nullable": true
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "entity_id",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "EntityProductStatus": {
+        "type": "string",
+        "enum": [
+          "unavailable",
+          "available",
+          "restricted"
+        ]
+      },
+      "EntityProduct": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/EntityProductStatus"
+          },
+          "status_error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "latest_request_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "latest_successful_request_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "is_subscribable": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "EntityProductListResponse": {
+        "type": "object",
+        "properties": {
+          "connect": {
+            "$ref": "#/components/schemas/EntityProduct"
+          },
+          "credit_score": {
+            "$ref": "#/components/schemas/EntityProduct"
+          },
+          "identity": {
+            "$ref": "#/components/schemas/EntityProduct"
+          },
+          "attribute": {
+            "$ref": "#/components/schemas/EntityProduct"
+          },
+          "vehicle": {
+            "$ref": "#/components/schemas/EntityProduct"
+          },
+          "manual_connect": {
+            "$ref": "#/components/schemas/EntityProduct"
+          }
+        }
+      },
+      "EntitySubscriptionStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "inactive"
+        ]
+      },
+      "EntitySubscription": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/EntitySubscriptionStatus"
+          },
+          "payload": {
+            "type": "object",
+            "nullable": true
+          },
+          "latest_request_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "EntitySubscriptionCreateRequest": {
+        "type": "object",
+        "properties": {
+          "enroll": {
+            "type": "string",
+            "enum": [
+              "connect",
+              "credit_score",
+              "attribute"
+            ]
+          },
+          "payload": {
+            "type": "object",
+            "nullable": true
+          }
+        },
+        "required": [
+          "enroll"
+        ]
+      },
+      "EntityVerificationSessionStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "in_progress",
+          "verified",
+          "failed"
+        ]
+      },
+      "EntityVerificationSessionType": {
+        "type": "string",
+        "enum": [
+          "phone",
+          "identity"
+        ]
+      },
+      "EntityVerificationSessionMethod": {
+        "type": "string",
+        "enum": [
+          "sms",
+          "sna",
+          "byo_sms",
+          "byo_kyc",
+          "kba",
+          "element",
+          "method_verified"
+        ]
+      },
+      "EntityVerificationSession": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/EntityVerificationSessionStatus"
+          },
+          "type": {
+            "$ref": "#/components/schemas/EntityVerificationSessionType"
+          },
+          "method": {
+            "$ref": "#/components/schemas/EntityVerificationSessionMethod"
+          },
+          "sms": {
+            "type": "object",
+            "nullable": true
+          },
+          "sna": {
+            "type": "object",
+            "nullable": true
+          },
+          "byo_sms": {
+            "type": "object",
+            "nullable": true
+          },
+          "byo_kyc": {
+            "type": "object",
+            "nullable": true
+          },
+          "kba": {
+            "type": "object",
+            "nullable": true
+          },
+          "element": {
+            "type": "object",
+            "nullable": true
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "entity_id",
+          "status",
+          "type",
+          "method",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "EntityVerificationSessionCreateRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/EntityVerificationSessionType"
+          },
+          "method": {
+            "$ref": "#/components/schemas/EntityVerificationSessionMethod"
+          },
+          "sms": {
+            "type": "object"
+          },
+          "sna": {
+            "type": "object"
+          },
+          "byo_sms": {
+            "type": "object"
+          },
+          "byo_kyc": {
+            "type": "object"
+          },
+          "kba": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "type",
+          "method"
+        ]
+      },
+      "EntityVerificationSessionUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/EntityVerificationSessionType"
+          },
+          "method": {
+            "$ref": "#/components/schemas/EntityVerificationSessionMethod"
+          },
+          "sms": {
+            "type": "object"
+          },
+          "sna": {
+            "type": "object"
+          },
+          "kba": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "type",
+          "method"
+        ]
+      },
+      "EntityWithdrawConsentRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "withdraw"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "entity_withdrew_consent"
+            ],
+            "nullable": true
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "AccountType": {
+        "type": "string",
+        "enum": [
+          "ach",
+          "liability"
+        ]
+      },
+      "AccountStatus": {
+        "type": "string",
+        "enum": [
+          "disabled",
+          "active",
+          "closed"
+        ]
+      },
+      "AccountLiabilityType": {
+        "type": "string",
+        "enum": [
+          "auto_loan",
+          "bnpl",
+          "credit_builder",
+          "credit_card",
+          "collection",
+          "fintech",
+          "insurance",
+          "loan",
+          "medical",
+          "mortgage",
+          "personal_loan",
+          "student_loans",
+          "utility"
+        ]
+      },
+      "AccountOwnership": {
+        "type": "string",
+        "enum": [
+          "primary",
+          "authorized",
+          "joint",
+          "unknown"
+        ]
+      },
+      "AccountACH": {
+        "type": "object",
+        "properties": {
+          "routing": {
+            "type": "string"
+          },
+          "number": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "savings",
+              "checking"
+            ]
+          }
+        },
+        "required": [
+          "routing",
+          "number",
+          "type"
+        ]
+      },
+      "AccountLiability": {
+        "type": "object",
+        "properties": {
+          "mch_id": {
+            "type": "string"
+          },
+          "mask": {
+            "type": "string",
+            "nullable": true
+          },
+          "ownership": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccountOwnership"
+              }
+            ],
+            "nullable": true
+          },
+          "fingerprint": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccountLiabilityType"
+              }
+            ],
+            "nullable": true
+          },
+          "sub_type": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Account": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "holder_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AccountStatus"
+          },
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccountType"
+              }
+            ],
+            "nullable": true
+          },
+          "ach": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccountACH"
+              }
+            ],
+            "nullable": true
+          },
+          "liability": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccountLiability"
+              }
+            ],
+            "nullable": true
+          },
+          "products": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "restricted_products": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "subscriptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "available_subscriptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "restricted_subscriptions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "sensitive": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/AccountSensitive"
+              }
+            ],
+            "nullable": true
+          },
+          "balance": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/AccountBalance"
+              }
+            ],
+            "nullable": true
+          },
+          "card_brand": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/AccountCardBrand"
+              }
+            ],
+            "nullable": true
+          },
+          "payoff": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/AccountPayoff"
+              }
+            ],
+            "nullable": true
+          },
+          "transactions": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AccountTransaction"
+                }
+              }
+            ],
+            "nullable": true
+          },
+          "update": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/AccountUpdate"
+              }
+            ],
+            "nullable": true
+          },
+          "attribute": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/AccountAttributes"
+              }
+            ],
+            "nullable": true
+          },
+          "payment_instrument": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/AccountPaymentInstrument"
+              }
+            ],
+            "nullable": true
+          },
+          "latest_verification_session": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/AccountVerificationSession"
+              }
+            ],
+            "nullable": true
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "holder_id",
+          "status",
+          "products",
+          "restricted_products",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "AccountACHCreateRequest": {
+        "type": "object",
+        "properties": {
+          "holder_id": {
+            "type": "string"
+          },
+          "ach": {
+            "$ref": "#/components/schemas/AccountACH"
+          },
+          "metadata": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "holder_id",
+          "ach"
+        ]
+      },
+      "AccountLiabilityCreateRequest": {
+        "type": "object",
+        "properties": {
+          "holder_id": {
+            "type": "string"
+          },
+          "liability": {
+            "type": "object",
+            "properties": {
+              "mch_id": {
+                "type": "string"
+              },
+              "account_number": {
+                "type": "string"
+              },
+              "number": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "mch_id"
+            ]
+          },
+          "metadata": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "holder_id",
+          "liability"
+        ]
+      },
+      "AccountCreateRequest": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/AccountACHCreateRequest"
+          },
+          {
+            "$ref": "#/components/schemas/AccountLiabilityCreateRequest"
+          }
+        ]
+      },
+      "AccountBalance": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "account_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "amount": {
+            "type": "integer",
+            "nullable": true
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "AccountCardBrandInfo": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "card_product_id": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "issuer": {
+            "type": "string"
+          },
+          "network": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "specific",
+              "generic",
+              "in_review"
+            ]
+          },
+          "url": {
+            "type": "string"
+          }
+        }
+      },
+      "AccountCardBrand": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "account_id": {
+            "type": "string"
+          },
+          "brands": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AccountCardBrandInfo"
+            }
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "method",
+              "network"
+            ],
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "in_progress",
+              "failed"
+            ]
+          },
+          "shared": {
+            "type": "boolean"
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "brands",
+          "status",
+          "shared",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "AccountPayoff": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "account_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "amount": {
+            "type": "integer",
+            "nullable": true
+          },
+          "term": {
+            "type": "integer",
+            "nullable": true
+          },
+          "per_diem_amount": {
+            "type": "integer",
+            "nullable": true
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "AccountSensitiveCreditCard": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "type": "string",
+            "nullable": true
+          },
+          "billing_zip_code": {
+            "type": "string",
+            "nullable": true
+          },
+          "exp_month": {
+            "type": "string",
+            "nullable": true
+          },
+          "exp_year": {
+            "type": "string",
+            "nullable": true
+          },
+          "cvv": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "AccountSensitiveLoan": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "type": "string"
+          }
+        }
+      },
+      "AccountSensitive": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "account_id": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/AccountLiabilityType"
+          },
+          "auto_loan": {
+            "$ref": "#/components/schemas/AccountSensitiveLoan"
+          },
+          "credit_card": {
+            "$ref": "#/components/schemas/AccountSensitiveCreditCard"
+          },
+          "mortgage": {
+            "$ref": "#/components/schemas/AccountSensitiveLoan"
+          },
+          "personal_loan": {
+            "$ref": "#/components/schemas/AccountSensitiveLoan"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "failed"
+            ]
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "type",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "AccountSensitiveCreateRequest": {
+        "type": "object",
+        "properties": {
+          "expand": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "auto_loan.number",
+                "mortgage.number",
+                "personal_loan.number",
+                "credit_card.number",
+                "credit_card.billing_zip_code",
+                "credit_card.exp_month",
+                "credit_card.exp_year",
+                "credit_card.cvv"
+              ]
+            }
+          }
+        },
+        "required": [
+          "expand"
+        ]
+      },
+      "TransactionMerchant": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "logo": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "AccountTransaction": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "account_id": {
+            "type": "string"
+          },
+          "descriptor": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer"
+          },
+          "auth_amount": {
+            "type": "integer"
+          },
+          "currency_code": {
+            "type": "string"
+          },
+          "transaction_amount": {
+            "type": "integer"
+          },
+          "transaction_auth_amount": {
+            "type": "integer"
+          },
+          "transaction_currency_code": {
+            "type": "string"
+          },
+          "merchant": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransactionMerchant"
+              }
+            ],
+            "nullable": true
+          },
+          "merchant_category_code": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "posted",
+              "voided"
+            ]
+          },
+          "transacted_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "posted_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "voided_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "original_txn_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "descriptor",
+          "amount",
+          "status",
+          "transacted_at",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "AccountUpdate": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "account_id": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "direct",
+              "snapshot"
+            ]
+          },
+          "type": {
+            "$ref": "#/components/schemas/AccountLiabilityType"
+          },
+          "auto_loan": {
+            "type": "object"
+          },
+          "credit_card": {
+            "type": "object"
+          },
+          "collection": {
+            "type": "object"
+          },
+          "mortgage": {
+            "type": "object"
+          },
+          "personal_loan": {
+            "type": "object"
+          },
+          "student_loans": {
+            "type": "object"
+          },
+          "credit_builder": {
+            "type": "object"
+          },
+          "loan": {
+            "type": "object"
+          },
+          "insurance": {
+            "type": "object"
+          },
+          "medical": {
+            "type": "object"
+          },
+          "utility": {
+            "type": "object"
+          },
+          "data_as_of": {
+            "type": "string",
+            "nullable": true
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "account_id",
+          "source",
+          "type",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "AccountAttributes": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "account_id": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "attributes": {
+            "type": "object",
+            "nullable": true
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "AccountPaymentInstrument": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "account_id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "card",
+              "network_token"
+            ]
+          },
+          "network_token": {
+            "type": "object",
+            "nullable": true
+          },
+          "card": {
+            "type": "object",
+            "nullable": true
+          },
+          "chargeable": {
+            "type": "boolean"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ResourceStatus"
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "type",
+          "chargeable",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "AccountPaymentInstrumentCreateRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "card",
+              "network_token"
+            ]
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "AccountVerificationSessionType": {
+        "type": "string",
+        "enum": [
+          "micro_deposits",
+          "plaid",
+          "mx",
+          "teller",
+          "standard",
+          "instant",
+          "pre_auth",
+          "network"
+        ]
+      },
+      "AccountVerificationSession": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "account_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "in_progress",
+              "verified",
+              "failed"
+            ]
+          },
+          "type": {
+            "$ref": "#/components/schemas/AccountVerificationSessionType"
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "plaid": {
+            "type": "object",
+            "nullable": true
+          },
+          "mx": {
+            "type": "object",
+            "nullable": true
+          },
+          "teller": {
+            "type": "object",
+            "nullable": true
+          },
+          "micro_deposits": {
+            "type": "object",
+            "nullable": true
+          },
+          "trusted_provisioner": {
+            "type": "object",
+            "nullable": true
+          },
+          "auto_verify": {
+            "type": "object",
+            "nullable": true
+          },
+          "standard": {
+            "type": "object",
+            "nullable": true
+          },
+          "instant": {
+            "type": "object",
+            "nullable": true
+          },
+          "pre_auth": {
+            "type": "object",
+            "nullable": true
+          },
+          "network": {
+            "type": "object",
+            "nullable": true
+          },
+          "three_ds": {
+            "type": "object",
+            "nullable": true
+          },
+          "issuer": {
+            "type": "object",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "account_id",
+          "status",
+          "type",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "AccountVerificationSessionCreateRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/AccountVerificationSessionType"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "AccountVerificationSessionUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "micro_deposits": {
+            "type": "object"
+          },
+          "plaid": {
+            "type": "object"
+          },
+          "mx": {
+            "type": "object"
+          },
+          "teller": {
+            "type": "object"
+          },
+          "standard": {
+            "type": "object"
+          },
+          "instant": {
+            "type": "object"
+          },
+          "pre_auth": {
+            "type": "object"
+          },
+          "network": {
+            "type": "object"
+          }
+        }
+      },
+      "AccountProduct": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "unavailable",
+              "available",
+              "restricted"
+            ]
+          },
+          "status_error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "latest_request_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "latest_successful_request_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "is_subscribable": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AccountSubscription": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "inactive"
+            ]
+          },
+          "payload": {
+            "type": "object",
+            "nullable": true
+          },
+          "latest_request_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AccountSubscriptionCreateRequest": {
+        "type": "object",
+        "properties": {
+          "enroll": {
+            "type": "string",
+            "enum": [
+              "card_brand",
+              "payment_instrument",
+              "transaction",
+              "update",
+              "update.snapshot"
+            ]
+          }
+        },
+        "required": [
+          "enroll"
+        ]
+      },
+      "AccountWithdrawConsentRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "withdraw"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "holder_withdrew_consent"
+            ],
+            "nullable": true
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "PaymentStatus": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "canceled",
+          "processing",
+          "failed",
+          "sent",
+          "posted",
+          "reversed",
+          "reversal_required",
+          "reversal_processing",
+          "settled",
+          "cashed"
+        ]
+      },
+      "PaymentFundStatus": {
+        "type": "string",
+        "enum": [
+          "hold",
+          "pending",
+          "requested",
+          "clearing",
+          "failed",
+          "sent",
+          "posted",
+          "unknown"
+        ]
+      },
+      "PaymentType": {
+        "type": "string",
+        "enum": [
+          "standard",
+          "clearing"
+        ]
+      },
+      "PaymentFee": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "total",
+              "markup"
+            ]
+          },
+          "amount": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "type",
+          "amount"
+        ]
+      },
+      "Payment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "reversal_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "source_trace_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "destination_trace_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "source": {
+            "type": "string"
+          },
+          "destination": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PaymentStatus"
+          },
+          "fund_status": {
+            "$ref": "#/components/schemas/PaymentFundStatus"
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true
+          },
+          "estimated_completion_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "source_settlement_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "destination_settlement_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "source_status": {
+            "$ref": "#/components/schemas/PaymentStatus"
+          },
+          "destination_status": {
+            "$ref": "#/components/schemas/PaymentStatus"
+          },
+          "destination_payment_method": {
+            "type": "string",
+            "enum": [
+              "paper",
+              "electronic"
+            ],
+            "nullable": true
+          },
+          "fee": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaymentFee"
+              }
+            ],
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/PaymentType"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "source",
+          "destination",
+          "amount",
+          "description",
+          "status",
+          "type",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "PaymentCreateRequest": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "destination": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "fee": {
+            "$ref": "#/components/schemas/PaymentFee"
+          },
+          "dry_run": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "amount",
+          "source",
+          "destination",
+          "description"
+        ]
+      },
+      "ReversalStatus": {
+        "type": "string",
+        "enum": [
+          "pending_approval",
+          "pending",
+          "processing",
+          "sent",
+          "failed"
+        ]
+      },
+      "ReversalDirection": {
+        "type": "string",
+        "enum": [
+          "debit",
+          "credit"
+        ]
+      },
+      "Reversal": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "pmt_id": {
+            "type": "string"
+          },
+          "target_account": {
+            "type": "string"
+          },
+          "trace_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "direction": {
+            "$ref": "#/components/schemas/ReversalDirection"
+          },
+          "description": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ReversalStatus"
+          },
+          "error": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ResourceError"
+              }
+            ],
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "pmt_id",
+          "target_account",
+          "direction",
+          "description",
+          "amount",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "ReversalUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ReversalStatus"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "WebhookType": {
+        "type": "string",
+        "enum": [
+          "payment.create",
+          "payment.update",
+          "account.create",
+          "account.update",
+          "entity.update",
+          "entity.create",
+          "account_verification.create",
+          "account_verification.update",
+          "payment_reversal.create",
+          "payment_reversal.update",
+          "connection.create",
+          "connection.update",
+          "transaction.create",
+          "transaction.update",
+          "report.create",
+          "report.update",
+          "product.create",
+          "product.update",
+          "subscription.create",
+          "subscription.update",
+          "credit_score.create",
+          "credit_score.update",
+          "payoff.create",
+          "payoff.update",
+          "entity_verification_session.create",
+          "entity_verification_session.update",
+          "connect.create",
+          "connect.update",
+          "connect.available",
+          "balance.create",
+          "balance.update",
+          "identity.create",
+          "identity.update",
+          "account_verification_session.create",
+          "account_verification_session.update",
+          "card_brand.create",
+          "card_brand.update",
+          "card_brand.available",
+          "sensitive.create",
+          "sensitive.update",
+          "update.create",
+          "update.update",
+          "attribute.create",
+          "attribute.update",
+          "account.opened",
+          "account.closed",
+          "credit_score.increased",
+          "credit_score.decreased"
+        ]
+      },
+      "WebhookStatus": {
+        "type": "string",
+        "enum": [
+          "active",
+          "disabled",
+          "deleted",
+          "requires_attention"
+        ]
+      },
+      "Webhook": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/WebhookType"
+          },
+          "url": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expand_event": {
+            "type": "boolean"
+          },
+          "error": {
+            "type": "object",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "url",
+          "created_at",
+          "updated_at",
+          "expand_event"
+        ]
+      },
+      "WebhookCreateRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/WebhookType"
+          },
+          "url": {
+            "type": "string"
+          },
+          "auth_token": {
+            "type": "string"
+          },
+          "hmac_secret": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "expand_event": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "type",
+          "url"
+        ]
+      },
+      "WebhookUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "active",
+              "disabled"
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "ReportType": {
+        "type": "string",
+        "enum": [
+          "payments.created.current",
+          "payments.created.previous",
+          "payments.updated.current",
+          "payments.updated.previous",
+          "payments.created.previous_day",
+          "payments.failed.previous_day",
+          "ach.pull.upcoming",
+          "ach.pull.previous",
+          "ach.pull.nightly",
+          "ach.reversals.nightly",
+          "entities.created.previous_day"
+        ]
+      },
+      "ReportStatus": {
+        "type": "string",
+        "enum": [
+          "processing",
+          "completed"
+        ]
+      },
+      "Report": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/ReportType"
+          },
+          "url": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ReportStatus"
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "url",
+          "status",
+          "created_at",
+          "updated_at"
+        ]
+      },
+      "ReportCreateRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/ReportType"
+          },
+          "metadata": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "MerchantProviderIds": {
+        "type": "object",
+        "properties": {
+          "plaid": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "mx": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "finicity": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "dpp": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Merchant": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "parent_name": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "logo": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/AccountLiabilityType"
+          },
+          "provider_ids": {
+            "$ref": "#/components/schemas/MerchantProviderIds"
+          },
+          "is_temp": {
+            "type": "boolean"
+          },
+          "account_number_formats": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "parent_name",
+          "name",
+          "logo",
+          "type",
+          "provider_ids",
+          "is_temp",
+          "account_number_formats"
+        ]
+      },
+      "EventResourceType": {
+        "type": "string",
+        "enum": [
+          "account",
+          "credit_score",
+          "attribute",
+          "connect"
+        ]
+      },
+      "EventDiff": {
+        "type": "object",
+        "properties": {
+          "before": {
+            "type": "object",
+            "nullable": true
+          },
+          "after": {
+            "type": "object",
+            "nullable": true
+          }
+        }
+      },
+      "Event": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/WebhookType"
+          },
+          "resource_id": {
+            "type": "string"
+          },
+          "resource_type": {
+            "$ref": "#/components/schemas/EventResourceType"
+          },
+          "data": {
+            "type": "object"
+          },
+          "diff": {
+            "$ref": "#/components/schemas/EventDiff"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "resource_id",
+          "resource_type",
+          "data",
+          "diff",
+          "updated_at",
+          "created_at"
+        ]
+      },
+      "ElementType": {
+        "type": "string",
+        "enum": [
+          "connect",
+          "balance_transfer"
+        ]
+      },
+      "ElementToken": {
+        "type": "object",
+        "properties": {
+          "element_token": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "element_token"
+        ]
+      },
+      "ElementUserEvent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "nullable": true
+          }
+        }
+      },
+      "ElementResults": {
+        "type": "object",
+        "properties": {
+          "authenticated": {
+            "type": "boolean"
+          },
+          "cxn_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "accounts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "entity_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ElementUserEvent"
+            }
+          }
+        },
+        "required": [
+          "authenticated",
+          "accounts",
+          "events"
+        ]
+      },
+      "ElementTokenCreateRequest": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "$ref": "#/components/schemas/ElementType"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "team_name": {
+            "type": "string"
+          },
+          "team_logo": {
+            "type": "string",
+            "nullable": true
+          },
+          "team_icon": {
+            "type": "string",
+            "nullable": true
+          },
+          "connect": {
+            "type": "object"
+          },
+          "balance_transfer": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "type"
+        ]
+      },
+      "OpalMode": {
+        "type": "string",
+        "enum": [
+          "identity_verification",
+          "connect",
+          "card_connect",
+          "account_verification",
+          "transactions"
+        ]
+      },
+      "OpalToken": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "valid_until": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "token",
+          "valid_until",
+          "session_id"
+        ]
+      },
+      "OpalTokenCreateRequest": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/OpalMode"
+          },
+          "entity_id": {
+            "type": "string"
+          },
+          "identity_verification": {
+            "type": "object"
+          },
+          "connect": {
+            "type": "object"
+          },
+          "card_connect": {
+            "type": "object"
+          },
+          "account_verification": {
+            "type": "object"
+          },
+          "transactions": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "mode",
+          "entity_id"
+        ]
+      },
+      "SimulatePaymentUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/PaymentStatus"
+          },
+          "error_code": {
+            "type": "integer",
+            "nullable": true
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "SimulateEntityConnectRequest": {
+        "type": "object",
+        "properties": {
+          "behaviors": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "new_credit_card_account",
+                "new_auto_loan_account",
+                "new_mortgage_account",
+                "new_student_loan_account",
+                "new_personal_loan_account"
+              ]
+            }
+          }
+        },
+        "required": [
+          "behaviors"
+        ]
+      },
+      "SimulateEntityAttributesRequest": {
+        "type": "object",
+        "properties": {
+          "behaviors": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "new_soft_inquiry"
+              ]
+            }
+          }
+        },
+        "required": [
+          "behaviors"
+        ]
+      }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "headers": {
+      "IdemRequestId": {
+        "description": "Unique request identifier for tracking and debugging",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "IdemStatus": {
+        "description": "Idempotency status indicating how the request was processed",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "stored",
+            "bypassed",
+            "replayed"
+          ]
+        }
+      },
+      "PaginationPage": {
+        "description": "Current page number",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "PaginationPageCount": {
+        "description": "Total number of pages available",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "PaginationPageLimit": {
+        "description": "Number of items per page",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "PaginationTotalCount": {
+        "description": "Total number of items across all pages",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "PaginationPageCursorNext": {
+        "description": "Cursor for fetching the next page",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "PaginationPageCursorPrev": {
+        "description": "Cursor for fetching the previous page",
+        "schema": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,5955 @@
+openapi: 3.0.3
+info:
+  title: Method API
+  version: '2025-07-04'
+  description: Method Financial API - Node SDK Generated OpenAPI Specification
+  contact:
+    name: Method Financial
+    url: https://methodfi.com
+    email: support@methodfi.com
+servers:
+  - url: https://production.methodfi.com
+    description: Production
+  - url: https://sandbox.methodfi.com
+    description: Sandbox
+  - url: https://dev.methodfi.com
+    description: Development
+tags:
+  - name: Entities
+    description: Entity management endpoints
+  - name: Entities - Connect
+    description: Entity connection endpoints
+  - name: Entities - Credit Scores
+    description: Entity credit score endpoints
+  - name: Entities - Identities
+    description: Entity identity endpoints
+  - name: Entities - Attributes
+    description: Entity attribute endpoints
+  - name: Entities - Vehicles
+    description: Entity vehicle endpoints
+  - name: Entities - Products
+    description: Entity product endpoints
+  - name: Entities - Subscriptions
+    description: Entity subscription endpoints
+  - name: Entities - Verification Sessions
+    description: Entity verification session endpoints
+  - name: Accounts
+    description: Account management endpoints
+  - name: Accounts - Balances
+    description: Account balance endpoints
+  - name: Accounts - CardBrands
+    description: Account card brand endpoints
+  - name: Accounts - Payoffs
+    description: Account payoff endpoints
+  - name: Accounts - Sensitives
+    description: Account sensitive data endpoints
+  - name: Accounts - Transactions
+    description: Account transaction endpoints
+  - name: Accounts - Updates
+    description: Account update endpoints
+  - name: Accounts - Attributess
+    description: Account attribute endpoints
+  - name: Accounts - PaymentInstruments
+    description: Account payment instrument endpoints
+  - name: Accounts - Subscriptions
+    description: Account subscription endpoints
+  - name: Accounts - Products
+    description: Account product endpoints
+  - name: Accounts - Verification Sessions
+    description: Account verification session endpoints
+  - name: Payments
+    description: Payment management endpoints
+  - name: Payments - Reversals
+    description: Payment reversal endpoints
+  - name: Webhooks
+    description: Webhook management endpoints
+  - name: Reports
+    description: Report management endpoints
+  - name: Merchants
+    description: Merchant lookup endpoints
+  - name: Events
+    description: Event retrieval endpoints
+  - name: Elements
+    description: Element token endpoints
+  - name: Opal
+    description: Opal token endpoints
+  - name: Simulate
+    description: Simulation endpoints for testing
+security:
+  - bearerAuth: []
+paths:
+  /entities:
+    get:
+      operationId: listEntities
+      summary: List all entities
+      description: List all entities. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Entity'
+      parameters:
+        - name: from_date
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: to_date
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page_limit
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page_cursor
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: expand
+          in: query
+          required: false
+          schema:
+            type: string
+    post:
+      operationId: createEntity
+      summary: Create a new entity
+      description: Create a new entity. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityCreateRequest'
+  /entities/{ent_id}:
+    get:
+      operationId: retrieveEntity
+      summary: Retrieve an entity
+      description: Retrieve an entity. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: expand
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - connect
+                - credit_score
+                - attribute
+                - vehicle
+                - identity_latest_verification_session
+                - phone_latest_verification_session
+          description: Fields to expand in the response. Can specify multiple values.
+          style: form
+          explode: true
+    put:
+      operationId: updateEntity
+      summary: Update an entity
+      description: Update an entity. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityUpdateRequest'
+  /entities/{ent_id}/consent:
+    post:
+      operationId: withdrawEntityConsent
+      summary: Withdraw entity consent
+      description: Withdraw entity consent. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Entity'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityWithdrawConsentRequest'
+  /entities/{ent_id}/connect:
+    get:
+      operationId: listEntityConnect
+      summary: List entity connect records
+      description: List entity connect records. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Connect
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntityConnect'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createEntityConnect
+      summary: Create entity connect
+      description: Create entity connect. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Connect
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityConnect'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityConnectCreateRequest'
+  /entities/{ent_id}/connect/{cxn_id}:
+    get:
+      operationId: retrieveEntityConnect
+      summary: Retrieve entity connect
+      description: Retrieve entity connect. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Connect
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityConnect'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: cxn_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /entities/{ent_id}/credit_scores:
+    get:
+      operationId: listEntityCreditScores
+      summary: List entity credit scores
+      description: List entity credit scores. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Credit Scores
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntityCreditScores'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createEntityCreditScores
+      summary: Create entity credit scores request
+      description: Create entity credit scores request. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Credit Scores
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityCreditScores'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+  /entities/{ent_id}/credit_scores/{crs_id}:
+    get:
+      operationId: retrieveEntityCreditScores
+      summary: Retrieve entity credit scores
+      description: Retrieve entity credit scores. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Credit Scores
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityCreditScores'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: crs_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /entities/{ent_id}/identities:
+    get:
+      operationId: listEntityIdentities
+      summary: List entity identities
+      description: List entity identities. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Identities
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntityIdentity'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createEntityIdentity
+      summary: Create entity identity request
+      description: Create entity identity request. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Identities
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityIdentity'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+  /entities/{ent_id}/identities/{idn_id}:
+    get:
+      operationId: retrieveEntityIdentity
+      summary: Retrieve entity identity
+      description: Retrieve entity identity. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Identities
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityIdentity'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: idn_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /entities/{ent_id}/attributes:
+    get:
+      operationId: listEntityAttributes
+      summary: List entity attributes
+      description: List entity attributes. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Attributes
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntityAttributes'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createEntityAttributes
+      summary: Create entity attributes request
+      description: Create entity attributes request. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Attributes
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityAttributes'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityAttributesCreateRequest'
+  /entities/{ent_id}/attributes/{atr_id}:
+    get:
+      operationId: retrieveEntityAttributes
+      summary: Retrieve entity attributes
+      description: Retrieve entity attributes. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Attributes
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityAttributes'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: atr_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /entities/{ent_id}/vehicles:
+    get:
+      operationId: listEntityVehicles
+      summary: List entity vehicles
+      description: List entity vehicles. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Vehicles
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntityVehicles'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createEntityVehicles
+      summary: Create entity vehicles request
+      description: Create entity vehicles request. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Vehicles
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityVehicles'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+  /entities/{ent_id}/vehicles/{vhl_id}:
+    get:
+      operationId: retrieveEntityVehicles
+      summary: Retrieve entity vehicles
+      description: Retrieve entity vehicles. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Vehicles
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityVehicles'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: vhl_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /entities/{ent_id}/products:
+    get:
+      operationId: listEntityProducts
+      summary: List entity products
+      description: List entity products. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Products
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityProductListResponse'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /entities/{ent_id}/subscriptions:
+    get:
+      operationId: listEntitySubscriptions
+      summary: List entity subscriptions
+      description: List entity subscriptions. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Subscriptions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntitySubscription'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createEntitySubscription
+      summary: Create entity subscription
+      description: Create entity subscription. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Subscriptions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntitySubscription'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntitySubscriptionCreateRequest'
+  /entities/{ent_id}/subscriptions/{sub_id}:
+    get:
+      operationId: retrieveEntitySubscription
+      summary: Retrieve entity subscription
+      description: Retrieve entity subscription. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Subscriptions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntitySubscription'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: sub_id
+          in: path
+          required: true
+          schema:
+            type: string
+    delete:
+      operationId: deleteEntitySubscription
+      summary: Delete entity subscription
+      description: Delete entity subscription. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Subscriptions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntitySubscription'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: sub_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /entities/{ent_id}/verification_sessions:
+    get:
+      operationId: listEntityVerificationSessions
+      summary: List entity verification sessions
+      description: List entity verification sessions. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Verification Sessions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntityVerificationSession'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createEntityVerificationSession
+      summary: Create entity verification session
+      description: Create entity verification session. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Verification Sessions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityVerificationSession'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityVerificationSessionCreateRequest'
+  /entities/{ent_id}/verification_sessions/{evf_id}:
+    get:
+      operationId: retrieveEntityVerificationSession
+      summary: Retrieve entity verification session
+      description: Retrieve entity verification session. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Verification Sessions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityVerificationSession'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: evf_id
+          in: path
+          required: true
+          schema:
+            type: string
+    put:
+      operationId: updateEntityVerificationSession
+      summary: Update entity verification session
+      description: Update entity verification session. See https://docs.methodfi.com for more details.
+      tags:
+        - Entities - Verification Sessions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityVerificationSession'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: evf_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityVerificationSessionUpdateRequest'
+  /accounts:
+    get:
+      operationId: listAccounts
+      summary: List all accounts
+      description: List all accounts. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Account'
+      parameters:
+        - name: from_date
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: to_date
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page_limit
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page_cursor
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: holder_id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: expand
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - payment
+                - balance
+                - sensitive
+                - card_brand
+                - payoff
+                - update
+                - attribute
+                - transactions
+                - payment_instrument
+                - latest_verification_session
+          description: Fields to expand in the response. Can specify multiple values.
+          style: form
+          explode: true
+        - name: liability.mch_id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: liability.type
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: liability.ownership
+          in: query
+          required: false
+          schema:
+            type: string
+    post:
+      operationId: createAccount
+      summary: Create a new account
+      description: Create a new account. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountCreateRequest'
+  /accounts/{acc_id}:
+    get:
+      operationId: retrieveAccount
+      summary: Retrieve an account
+      description: Retrieve an account. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: expand
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - payment
+                - balance
+                - sensitive
+                - card_brand
+                - payoff
+                - update
+                - attribute
+                - transactions
+                - payment_instrument
+                - latest_verification_session
+          description: Fields to expand in the response. Can specify multiple values.
+          style: form
+          explode: true
+  /accounts/{acc_id}/consent:
+    post:
+      operationId: withdrawAccountConsent
+      summary: Withdraw account consent
+      description: Withdraw account consent. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Account'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountWithdrawConsentRequest'
+  /accounts/{acc_id}/balances:
+    get:
+      operationId: listAccountBalances
+      summary: List account balances
+      description: List account balances. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Balances
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountBalance'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createAccountBalance
+      summary: Create account balance
+      description: Create account balance. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Balances
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountBalance'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+  /accounts/{acc_id}/balances/{balance_id}:
+    get:
+      operationId: retrieveAccountBalance
+      summary: Retrieve account balance
+      description: Retrieve account balance. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Balances
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountBalance'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: balance_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/card_brands:
+    get:
+      operationId: listAccountCardBrands
+      summary: List account card_brands
+      description: List account card_brands. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - CardBrands
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountCardBrand'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createAccountCardBrand
+      summary: Create account card_brand
+      description: Create account card_brand. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - CardBrands
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountCardBrand'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+  /accounts/{acc_id}/card_brands/{card_brand_id}:
+    get:
+      operationId: retrieveAccountCardBrand
+      summary: Retrieve account card_brand
+      description: Retrieve account card_brand. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - CardBrands
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountCardBrand'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: card_brand_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/payoffs:
+    get:
+      operationId: listAccountPayoffs
+      summary: List account payoffs
+      description: List account payoffs. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Payoffs
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountPayoff'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createAccountPayoff
+      summary: Create account payoff
+      description: Create account payoff. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Payoffs
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountPayoff'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+  /accounts/{acc_id}/payoffs/{payoff_id}:
+    get:
+      operationId: retrieveAccountPayoff
+      summary: Retrieve account payoff
+      description: Retrieve account payoff. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Payoffs
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountPayoff'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: payoff_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/sensitive:
+    get:
+      operationId: listAccountSensitives
+      summary: List account sensitive
+      description: List account sensitive. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Sensitives
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountSensitive'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createAccountSensitive
+      summary: Create account sensitiv
+      description: Create account sensitiv. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Sensitives
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountSensitive'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountSensitiveCreateRequest'
+  /accounts/{acc_id}/sensitive/{sensitiv_id}:
+    get:
+      operationId: retrieveAccountSensitive
+      summary: Retrieve account sensitiv
+      description: Retrieve account sensitiv. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Sensitives
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountSensitive'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: sensitiv_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/transactions:
+    get:
+      operationId: listAccountTransactions
+      summary: List account transactions
+      description: List account transactions. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Transactions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountTransaction'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/transactions/{transaction_id}:
+    get:
+      operationId: retrieveAccountTransaction
+      summary: Retrieve account transaction
+      description: Retrieve account transaction. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Transactions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountTransaction'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: transaction_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/updates:
+    get:
+      operationId: listAccountUpdates
+      summary: List account updates
+      description: List account updates. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Updates
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountUpdate'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createAccountUpdate
+      summary: Create account update
+      description: Create account update. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Updates
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountUpdate'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+  /accounts/{acc_id}/updates/{update_id}:
+    get:
+      operationId: retrieveAccountUpdate
+      summary: Retrieve account update
+      description: Retrieve account update. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Updates
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountUpdate'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: update_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/attributes:
+    get:
+      operationId: listAccountAttributess
+      summary: List account attributes
+      description: List account attributes. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Attributess
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountAttributes'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createAccountAttributes
+      summary: Create account attribute
+      description: Create account attribute. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Attributess
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountAttributes'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+  /accounts/{acc_id}/attributes/{attribute_id}:
+    get:
+      operationId: retrieveAccountAttributes
+      summary: Retrieve account attribute
+      description: Retrieve account attribute. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Attributess
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountAttributes'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: attribute_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/payment_instruments:
+    get:
+      operationId: listAccountPaymentInstruments
+      summary: List account payment_instruments
+      description: List account payment_instruments. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - PaymentInstruments
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountPaymentInstrument'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createAccountPaymentInstrument
+      summary: Create account payment_instrument
+      description: Create account payment_instrument. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - PaymentInstruments
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountPaymentInstrument'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountPaymentInstrumentCreateRequest'
+  /accounts/{acc_id}/payment_instruments/{payment_instrument_id}:
+    get:
+      operationId: retrieveAccountPaymentInstrument
+      summary: Retrieve account payment_instrument
+      description: Retrieve account payment_instrument. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - PaymentInstruments
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountPaymentInstrument'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: payment_instrument_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/subscriptions:
+    get:
+      operationId: listAccountSubscriptions
+      summary: List account subscriptions
+      description: List account subscriptions. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Subscriptions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountSubscription'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createAccountSubscription
+      summary: Create account subscription
+      description: Create account subscription. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Subscriptions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountSubscription'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountSubscriptionCreateRequest'
+  /accounts/{acc_id}/subscriptions/{sub_id}:
+    get:
+      operationId: retrieveAccountSubscription
+      summary: Retrieve account subscription
+      description: Retrieve account subscription. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Subscriptions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountSubscription'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: sub_id
+          in: path
+          required: true
+          schema:
+            type: string
+    delete:
+      operationId: deleteAccountSubscription
+      summary: Delete account subscription
+      description: Delete account subscription. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Subscriptions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountSubscription'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: sub_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/products:
+    get:
+      operationId: listAccountProducts
+      summary: List account products
+      description: List account products. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Products
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountProduct'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /accounts/{acc_id}/verification_sessions:
+    get:
+      operationId: listAccountVerificationSessions
+      summary: List account verification sessions
+      description: List account verification sessions. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Verification Sessions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AccountVerificationSession'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+    post:
+      operationId: createAccountVerificationSession
+      summary: Create account verification session
+      description: Create account verification session. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Verification Sessions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountVerificationSession'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountVerificationSessionCreateRequest'
+  /accounts/{acc_id}/verification_sessions/{avf_id}:
+    get:
+      operationId: retrieveAccountVerificationSession
+      summary: Retrieve account verification session
+      description: Retrieve account verification session. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Verification Sessions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountVerificationSession'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: avf_id
+          in: path
+          required: true
+          schema:
+            type: string
+    put:
+      operationId: updateAccountVerificationSession
+      summary: Update account verification session
+      description: Update account verification session. See https://docs.methodfi.com for more details.
+      tags:
+        - Accounts - Verification Sessions
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountVerificationSession'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: avf_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AccountVerificationSessionUpdateRequest'
+  /payments:
+    get:
+      operationId: listPayments
+      summary: List all payments
+      description: List all payments. See https://docs.methodfi.com for more details.
+      tags:
+        - Payments
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Payment'
+      parameters:
+        - name: from_date
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: to_date
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page_limit
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page_cursor
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: status
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: source
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: destination
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: reversal_id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: source_holder_id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: destination_holder_id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: acc_id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: holder_id
+          in: query
+          required: false
+          schema:
+            type: string
+    post:
+      operationId: createPayment
+      summary: Create a new payment
+      description: Create a new payment. See https://docs.methodfi.com for more details.
+      tags:
+        - Payments
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentCreateRequest'
+  /payments/{pmt_id}:
+    get:
+      operationId: retrievePayment
+      summary: Retrieve a payment
+      description: Retrieve a payment. See https://docs.methodfi.com for more details.
+      tags:
+        - Payments
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+      parameters:
+        - name: pmt_id
+          in: path
+          required: true
+          schema:
+            type: string
+    delete:
+      operationId: deletePayment
+      summary: Cancel a payment
+      description: Cancel a payment. See https://docs.methodfi.com for more details.
+      tags:
+        - Payments
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+      parameters:
+        - name: pmt_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /payments/{pmt_id}/reversals:
+    get:
+      operationId: listPaymentReversals
+      summary: List payment reversals
+      description: List payment reversals. See https://docs.methodfi.com for more details.
+      tags:
+        - Payments - Reversals
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Reversal'
+      parameters:
+        - name: pmt_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /payments/{pmt_id}/reversals/{rvs_id}:
+    get:
+      operationId: retrievePaymentReversal
+      summary: Retrieve payment reversal
+      description: Retrieve payment reversal. See https://docs.methodfi.com for more details.
+      tags:
+        - Payments - Reversals
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reversal'
+      parameters:
+        - name: pmt_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: rvs_id
+          in: path
+          required: true
+          schema:
+            type: string
+    put:
+      operationId: updatePaymentReversal
+      summary: Update payment reversal
+      description: Update payment reversal. See https://docs.methodfi.com for more details.
+      tags:
+        - Payments - Reversals
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Reversal'
+      parameters:
+        - name: pmt_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: rvs_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReversalUpdateRequest'
+  /webhooks:
+    get:
+      operationId: listWebhooks
+      summary: List all webhooks
+      description: List all webhooks. See https://docs.methodfi.com for more details.
+      tags:
+        - Webhooks
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Webhook'
+    post:
+      operationId: createWebhook
+      summary: Create a new webhook
+      description: Create a new webhook. See https://docs.methodfi.com for more details.
+      tags:
+        - Webhooks
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Webhook'
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookCreateRequest'
+  /webhooks/{whk_id}:
+    get:
+      operationId: retrieveWebhook
+      summary: Retrieve a webhook
+      description: Retrieve a webhook. See https://docs.methodfi.com for more details.
+      tags:
+        - Webhooks
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Webhook'
+      parameters:
+        - name: whk_id
+          in: path
+          required: true
+          schema:
+            type: string
+    patch:
+      operationId: updateWebhook
+      summary: Update a webhook
+      description: Update a webhook. See https://docs.methodfi.com for more details.
+      tags:
+        - Webhooks
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Webhook'
+      parameters:
+        - name: whk_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/WebhookUpdateRequest'
+    delete:
+      operationId: deleteWebhook
+      summary: Delete a webhook
+      description: Delete a webhook. See https://docs.methodfi.com for more details.
+      tags:
+        - Webhooks
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                type: object
+      parameters:
+        - name: whk_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /reports:
+    post:
+      operationId: createReport
+      summary: Create a new report
+      description: Create a new report. See https://docs.methodfi.com for more details.
+      tags:
+        - Reports
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Report'
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReportCreateRequest'
+  /reports/{rpt_id}:
+    get:
+      operationId: retrieveReport
+      summary: Retrieve a report
+      description: Retrieve a report. See https://docs.methodfi.com for more details.
+      tags:
+        - Reports
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Report'
+      parameters:
+        - name: rpt_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /reports/{rpt_id}/download:
+    get:
+      operationId: downloadReport
+      summary: Download a report
+      description: Download a report as CSV
+      tags:
+        - Reports
+      parameters:
+        - name: rpt_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Report CSV data
+          content:
+            text/csv:
+              schema:
+                type: string
+  /merchants:
+    get:
+      operationId: listMerchants
+      summary: List all merchants
+      description: List all merchants. See https://docs.methodfi.com for more details.
+      tags:
+        - Merchants
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Merchant'
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page_limit
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: name
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: creditor_name
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: provider_id.plaid
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: provider_id.mx
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: provider_id.finicity
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: provider_id.dpp
+          in: query
+          required: false
+          schema:
+            type: string
+  /merchants/{mch_id}:
+    get:
+      operationId: retrieveMerchant
+      summary: Retrieve a merchant
+      description: Retrieve a merchant. See https://docs.methodfi.com for more details.
+      tags:
+        - Merchants
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Merchant'
+      parameters:
+        - name: mch_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /events:
+    get:
+      operationId: listEvents
+      summary: List all events
+      description: List all events. See https://docs.methodfi.com for more details.
+      tags:
+        - Events
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+            pagination-page:
+              $ref: '#/components/headers/PaginationPage'
+            pagination-page-count:
+              $ref: '#/components/headers/PaginationPageCount'
+            pagination-page-limit:
+              $ref: '#/components/headers/PaginationPageLimit'
+            pagination-total-count:
+              $ref: '#/components/headers/PaginationTotalCount'
+            pagination-page-cursor-next:
+              $ref: '#/components/headers/PaginationPageCursorNext'
+            pagination-page-cursor-prev:
+              $ref: '#/components/headers/PaginationPageCursorPrev'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Event'
+      parameters:
+        - name: from_date
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: to_date
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page_limit
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: page_cursor
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: resource_id
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: resource_type
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+  /events/{evt_id}:
+    get:
+      operationId: retrieveEvent
+      summary: Retrieve an event
+      description: Retrieve an event. See https://docs.methodfi.com for more details.
+      tags:
+        - Events
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+      parameters:
+        - name: evt_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /elements/token:
+    post:
+      operationId: createElementToken
+      summary: Create an element token
+      description: Create an element token. See https://docs.methodfi.com for more details.
+      tags:
+        - Elements
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ElementToken'
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ElementTokenCreateRequest'
+  /elements/token/{pk_elem_id}/results:
+    get:
+      operationId: retrieveElementResults
+      summary: Retrieve element results
+      description: Retrieve element results. See https://docs.methodfi.com for more details.
+      tags:
+        - Elements
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ElementResults'
+      parameters:
+        - name: pk_elem_id
+          in: path
+          required: true
+          schema:
+            type: string
+  /opal/token:
+    post:
+      operationId: createOpalToken
+      summary: Create an opal token
+      description: Create an opal token. See https://docs.methodfi.com for more details.
+      tags:
+        - Opal
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpalToken'
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpalTokenCreateRequest'
+  /simulate/payments/{pmt_id}:
+    post:
+      operationId: simulatePaymentUpdate
+      summary: Simulate payment status update
+      description: Simulate payment status update. See https://docs.methodfi.com for more details.
+      tags:
+        - Simulate
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Payment'
+      parameters:
+        - name: pmt_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimulatePaymentUpdateRequest'
+  /simulate/accounts/{acc_id}/transactions:
+    post:
+      operationId: simulateAccountTransaction
+      summary: Simulate account transaction
+      description: Simulate account transaction. See https://docs.methodfi.com for more details.
+      tags:
+        - Simulate
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AccountTransaction'
+      parameters:
+        - name: acc_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+  /simulate/entities/{ent_id}/connect:
+    post:
+      operationId: simulateEntityConnect
+      summary: Simulate entity connect
+      description: Simulate entity connect. See https://docs.methodfi.com for more details.
+      tags:
+        - Simulate
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityConnect'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimulateEntityConnectRequest'
+  /simulate/entities/{ent_id}/credit_scores/{crs_id}:
+    post:
+      operationId: simulateEntityCreditScores
+      summary: Simulate entity credit scores
+      description: Simulate entity credit scores. See https://docs.methodfi.com for more details.
+      tags:
+        - Simulate
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityCreditScores'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: crs_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+  /simulate/entities/{ent_id}/attributes/{atr_id}:
+    post:
+      operationId: simulateEntityAttributes
+      summary: Simulate entity attributes
+      description: Simulate entity attributes. See https://docs.methodfi.com for more details.
+      tags:
+        - Simulate
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EntityAttributes'
+      parameters:
+        - name: ent_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: atr_id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimulateEntityAttributesRequest'
+  /simulate/events:
+    post:
+      operationId: simulateEvent
+      summary: Simulate an event
+      description: Simulate an event. See https://docs.methodfi.com for more details.
+      tags:
+        - Simulate
+      responses:
+        '200':
+          description: Successful response
+          headers:
+            idem-request-id:
+              $ref: '#/components/headers/IdemRequestId'
+            idem-status:
+              $ref: '#/components/headers/IdemStatus'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Event'
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: false
+          schema:
+            type: string
+          description: Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.
+        - name: Prefer
+          in: header
+          required: false
+          schema:
+            type: string
+            enum:
+              - respond-async
+              - respond-sync
+          description: Control response behavior. Use "respond-async" for long-running operations to get immediate response with status=pending.
+components:
+  schemas:
+    ResourceError:
+      type: object
+      properties:
+        type:
+          type: string
+        code:
+          type: integer
+        sub_type:
+          type: string
+        message:
+          type: string
+    ResourceStatus:
+      type: string
+      enum:
+        - completed
+        - in_progress
+        - pending
+        - failed
+    EntityType:
+      type: string
+      enum:
+        - individual
+        - corporation
+    EntityStatus:
+      type: string
+      enum:
+        - active
+        - incomplete
+        - disabled
+    EntityAddress:
+      type: object
+      properties:
+        line1:
+          type: string
+          nullable: true
+        line2:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        state:
+          type: string
+          nullable: true
+        zip:
+          type: string
+          nullable: true
+    EntityIndividual:
+      type: object
+      properties:
+        first_name:
+          type: string
+          nullable: true
+        last_name:
+          type: string
+          nullable: true
+        phone:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+        dob:
+          type: string
+          nullable: true
+        ssn:
+          type: string
+          nullable: true
+        ssn_4:
+          type: string
+          nullable: true
+    EntityCorporationOwner:
+      type: object
+      properties:
+        first_name:
+          type: string
+          nullable: true
+        last_name:
+          type: string
+          nullable: true
+        phone:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+        dob:
+          type: string
+          nullable: true
+        address:
+          $ref: '#/components/schemas/EntityAddress'
+    EntityCorporation:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+        dba:
+          type: string
+          nullable: true
+        ein:
+          type: string
+          nullable: true
+        owners:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityCorporationOwner'
+    Entity:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          allOf:
+            - $ref: '#/components/schemas/EntityType'
+          nullable: true
+        individual:
+          allOf:
+            - $ref: '#/components/schemas/EntityIndividual'
+          nullable: true
+        corporation:
+          allOf:
+            - $ref: '#/components/schemas/EntityCorporation'
+          nullable: true
+        address:
+          $ref: '#/components/schemas/EntityAddress'
+        status:
+          $ref: '#/components/schemas/EntityStatus'
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        metadata:
+          type: object
+          nullable: true
+        products:
+          type: array
+          items:
+            type: string
+        restricted_products:
+          type: array
+          items:
+            type: string
+        subscriptions:
+          type: array
+          items:
+            type: string
+        available_subscriptions:
+          type: array
+          items:
+            type: string
+        restricted_subscriptions:
+          type: array
+          items:
+            type: string
+        verification:
+          type: object
+          nullable: true
+        connect:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/EntityConnect'
+          nullable: true
+        credit_score:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/EntityCreditScores'
+          nullable: true
+        attribute:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/EntityAttributes'
+          nullable: true
+        vehicle:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/EntityVehicles'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - status
+        - created_at
+        - updated_at
+    EntityIndividualCreateRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - individual
+        individual:
+          $ref: '#/components/schemas/EntityIndividual'
+        address:
+          $ref: '#/components/schemas/EntityAddress'
+        metadata:
+          type: object
+          nullable: true
+      required:
+        - type
+        - individual
+    EntityCorporationCreateRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - corporation
+        corporation:
+          $ref: '#/components/schemas/EntityCorporation'
+        address:
+          $ref: '#/components/schemas/EntityAddress'
+        metadata:
+          type: object
+          nullable: true
+      required:
+        - type
+        - corporation
+    EntityCreateRequest:
+      oneOf:
+        - $ref: '#/components/schemas/EntityIndividualCreateRequest'
+        - $ref: '#/components/schemas/EntityCorporationCreateRequest'
+    EntityUpdateRequest:
+      type: object
+      properties:
+        address:
+          $ref: '#/components/schemas/EntityAddress'
+        corporation:
+          $ref: '#/components/schemas/EntityCorporation'
+        individual:
+          $ref: '#/components/schemas/EntityIndividual'
+    EntityConnect:
+      type: object
+      properties:
+        id:
+          type: string
+        entity_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+        accounts:
+          type: array
+          items:
+            type: string
+          nullable: true
+        requested_products:
+          type: array
+          items:
+            type: string
+        requested_subscriptions:
+          type: array
+          items:
+            type: string
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - entity_id
+        - status
+        - created_at
+        - updated_at
+    EntityConnectCreateRequest:
+      type: object
+      properties:
+        products:
+          type: array
+          items:
+            type: string
+        subscriptions:
+          type: array
+          items:
+            type: string
+    CreditScoreModel:
+      type: string
+      enum:
+        - vantage_4
+        - vantage_3
+    CreditReportBureau:
+      type: string
+      enum:
+        - experian
+        - equifax
+        - transunion
+    EntityCreditScoreFactor:
+      type: object
+      properties:
+        code:
+          type: string
+        description:
+          type: string
+    EntityCreditScoreItem:
+      type: object
+      properties:
+        score:
+          type: integer
+        source:
+          $ref: '#/components/schemas/CreditReportBureau'
+        model:
+          $ref: '#/components/schemas/CreditScoreModel'
+        factors:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityCreditScoreFactor'
+        created_at:
+          type: string
+          format: date-time
+    EntityCreditScores:
+      type: object
+      properties:
+        id:
+          type: string
+        entity_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+        scores:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityCreditScoreItem'
+          nullable: true
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - entity_id
+        - status
+        - created_at
+        - updated_at
+    EntityIdentityType:
+      type: object
+      properties:
+        first_name:
+          type: string
+          nullable: true
+        last_name:
+          type: string
+          nullable: true
+        phone:
+          type: string
+          nullable: true
+        dob:
+          type: string
+          nullable: true
+        address:
+          type: object
+          nullable: true
+        ssn:
+          type: string
+          nullable: true
+    EntityIdentity:
+      type: object
+      properties:
+        id:
+          type: string
+        entity_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+        identities:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityIdentityType'
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - entity_id
+        - status
+        - identities
+        - created_at
+        - updated_at
+    CreditHealthAttributeRating:
+      type: string
+      enum:
+        - excellent
+        - good
+        - fair
+        - needs_work
+    CreditHealthAttribute:
+      type: object
+      properties:
+        value:
+          type: number
+        rating:
+          $ref: '#/components/schemas/CreditHealthAttributeRating'
+        metadata:
+          type: object
+          nullable: true
+    EntityAttributesType:
+      type: object
+      properties:
+        credit_health_credit_card_usage:
+          $ref: '#/components/schemas/CreditHealthAttribute'
+        credit_health_derogatory_marks:
+          $ref: '#/components/schemas/CreditHealthAttribute'
+        credit_health_hard_inquiries:
+          $ref: '#/components/schemas/CreditHealthAttribute'
+        credit_health_soft_inquiries:
+          $ref: '#/components/schemas/CreditHealthAttribute'
+        credit_health_total_accounts:
+          $ref: '#/components/schemas/CreditHealthAttribute'
+        credit_health_credit_age:
+          $ref: '#/components/schemas/CreditHealthAttribute'
+        credit_health_payment_history:
+          $ref: '#/components/schemas/CreditHealthAttribute'
+        credit_health_open_accounts:
+          $ref: '#/components/schemas/CreditHealthAttribute'
+        credit_health_entity_delinquent:
+          $ref: '#/components/schemas/CreditHealthAttribute'
+    EntityAttributes:
+      type: object
+      properties:
+        id:
+          type: string
+        entity_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+        attributes:
+          allOf:
+            - $ref: '#/components/schemas/EntityAttributesType'
+          nullable: true
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - entity_id
+        - status
+        - created_at
+        - updated_at
+    EntityAttributesCreateRequest:
+      type: object
+      properties:
+        attributes:
+          type: array
+          items:
+            type: string
+            enum:
+              - credit_health_credit_card_usage
+              - credit_health_derogatory_marks
+              - credit_health_hard_inquiries
+              - credit_health_soft_inquiries
+              - credit_health_total_accounts
+              - credit_health_credit_age
+              - credit_health_payment_history
+              - credit_health_open_accounts
+              - credit_health_entity_delinquent
+      required:
+        - attributes
+    EntityVehicleType:
+      type: object
+      properties:
+        vin:
+          type: string
+          nullable: true
+        year:
+          type: string
+          nullable: true
+        make:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        series:
+          type: string
+          nullable: true
+        major_color:
+          type: string
+          nullable: true
+        style:
+          type: string
+          nullable: true
+    EntityVehicles:
+      type: object
+      properties:
+        id:
+          type: string
+        entity_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+        vehicles:
+          type: array
+          items:
+            $ref: '#/components/schemas/EntityVehicleType'
+          nullable: true
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - entity_id
+        - status
+        - created_at
+        - updated_at
+    EntityProductStatus:
+      type: string
+      enum:
+        - unavailable
+        - available
+        - restricted
+    EntityProduct:
+      type: object
+      properties:
+        name:
+          type: string
+        status:
+          $ref: '#/components/schemas/EntityProductStatus'
+        status_error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        latest_request_id:
+          type: string
+          nullable: true
+        latest_successful_request_id:
+          type: string
+          nullable: true
+        is_subscribable:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    EntityProductListResponse:
+      type: object
+      properties:
+        connect:
+          $ref: '#/components/schemas/EntityProduct'
+        credit_score:
+          $ref: '#/components/schemas/EntityProduct'
+        identity:
+          $ref: '#/components/schemas/EntityProduct'
+        attribute:
+          $ref: '#/components/schemas/EntityProduct'
+        vehicle:
+          $ref: '#/components/schemas/EntityProduct'
+        manual_connect:
+          $ref: '#/components/schemas/EntityProduct'
+    EntitySubscriptionStatus:
+      type: string
+      enum:
+        - active
+        - inactive
+    EntitySubscription:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          $ref: '#/components/schemas/EntitySubscriptionStatus'
+        payload:
+          type: object
+          nullable: true
+        latest_request_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    EntitySubscriptionCreateRequest:
+      type: object
+      properties:
+        enroll:
+          type: string
+          enum:
+            - connect
+            - credit_score
+            - attribute
+        payload:
+          type: object
+          nullable: true
+      required:
+        - enroll
+    EntityVerificationSessionStatus:
+      type: string
+      enum:
+        - pending
+        - in_progress
+        - verified
+        - failed
+    EntityVerificationSessionType:
+      type: string
+      enum:
+        - phone
+        - identity
+    EntityVerificationSessionMethod:
+      type: string
+      enum:
+        - sms
+        - sna
+        - byo_sms
+        - byo_kyc
+        - kba
+        - element
+        - method_verified
+    EntityVerificationSession:
+      type: object
+      properties:
+        id:
+          type: string
+        entity_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/EntityVerificationSessionStatus'
+        type:
+          $ref: '#/components/schemas/EntityVerificationSessionType'
+        method:
+          $ref: '#/components/schemas/EntityVerificationSessionMethod'
+        sms:
+          type: object
+          nullable: true
+        sna:
+          type: object
+          nullable: true
+        byo_sms:
+          type: object
+          nullable: true
+        byo_kyc:
+          type: object
+          nullable: true
+        kba:
+          type: object
+          nullable: true
+        element:
+          type: object
+          nullable: true
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - entity_id
+        - status
+        - type
+        - method
+        - created_at
+        - updated_at
+    EntityVerificationSessionCreateRequest:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/EntityVerificationSessionType'
+        method:
+          $ref: '#/components/schemas/EntityVerificationSessionMethod'
+        sms:
+          type: object
+        sna:
+          type: object
+        byo_sms:
+          type: object
+        byo_kyc:
+          type: object
+        kba:
+          type: object
+      required:
+        - type
+        - method
+    EntityVerificationSessionUpdateRequest:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/EntityVerificationSessionType'
+        method:
+          $ref: '#/components/schemas/EntityVerificationSessionMethod'
+        sms:
+          type: object
+        sna:
+          type: object
+        kba:
+          type: object
+      required:
+        - type
+        - method
+    EntityWithdrawConsentRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - withdraw
+        reason:
+          type: string
+          enum:
+            - entity_withdrew_consent
+          nullable: true
+      required:
+        - type
+    AccountType:
+      type: string
+      enum:
+        - ach
+        - liability
+    AccountStatus:
+      type: string
+      enum:
+        - disabled
+        - active
+        - closed
+    AccountLiabilityType:
+      type: string
+      enum:
+        - auto_loan
+        - bnpl
+        - credit_builder
+        - credit_card
+        - collection
+        - fintech
+        - insurance
+        - loan
+        - medical
+        - mortgage
+        - personal_loan
+        - student_loans
+        - utility
+    AccountOwnership:
+      type: string
+      enum:
+        - primary
+        - authorized
+        - joint
+        - unknown
+    AccountACH:
+      type: object
+      properties:
+        routing:
+          type: string
+        number:
+          type: string
+        type:
+          type: string
+          enum:
+            - savings
+            - checking
+      required:
+        - routing
+        - number
+        - type
+    AccountLiability:
+      type: object
+      properties:
+        mch_id:
+          type: string
+        mask:
+          type: string
+          nullable: true
+        ownership:
+          allOf:
+            - $ref: '#/components/schemas/AccountOwnership'
+          nullable: true
+        fingerprint:
+          type: string
+          nullable: true
+        type:
+          allOf:
+            - $ref: '#/components/schemas/AccountLiabilityType'
+          nullable: true
+        sub_type:
+          type: string
+          nullable: true
+        name:
+          type: string
+          nullable: true
+    Account:
+      type: object
+      properties:
+        id:
+          type: string
+        holder_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/AccountStatus'
+        type:
+          allOf:
+            - $ref: '#/components/schemas/AccountType'
+          nullable: true
+        ach:
+          allOf:
+            - $ref: '#/components/schemas/AccountACH'
+          nullable: true
+        liability:
+          allOf:
+            - $ref: '#/components/schemas/AccountLiability'
+          nullable: true
+        products:
+          type: array
+          items:
+            type: string
+        restricted_products:
+          type: array
+          items:
+            type: string
+        subscriptions:
+          type: array
+          items:
+            type: string
+        available_subscriptions:
+          type: array
+          items:
+            type: string
+        restricted_subscriptions:
+          type: array
+          items:
+            type: string
+        sensitive:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/AccountSensitive'
+          nullable: true
+        balance:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/AccountBalance'
+          nullable: true
+        card_brand:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/AccountCardBrand'
+          nullable: true
+        payoff:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/AccountPayoff'
+          nullable: true
+        transactions:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/AccountTransaction'
+          nullable: true
+        update:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/AccountUpdate'
+          nullable: true
+        attribute:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/AccountAttributes'
+          nullable: true
+        payment_instrument:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/AccountPaymentInstrument'
+          nullable: true
+        latest_verification_session:
+          oneOf:
+            - type: string
+            - $ref: '#/components/schemas/AccountVerificationSession'
+          nullable: true
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          nullable: true
+      required:
+        - id
+        - holder_id
+        - status
+        - products
+        - restricted_products
+        - created_at
+        - updated_at
+    AccountACHCreateRequest:
+      type: object
+      properties:
+        holder_id:
+          type: string
+        ach:
+          $ref: '#/components/schemas/AccountACH'
+        metadata:
+          type: object
+      required:
+        - holder_id
+        - ach
+    AccountLiabilityCreateRequest:
+      type: object
+      properties:
+        holder_id:
+          type: string
+        liability:
+          type: object
+          properties:
+            mch_id:
+              type: string
+            account_number:
+              type: string
+            number:
+              type: string
+          required:
+            - mch_id
+        metadata:
+          type: object
+      required:
+        - holder_id
+        - liability
+    AccountCreateRequest:
+      oneOf:
+        - $ref: '#/components/schemas/AccountACHCreateRequest'
+        - $ref: '#/components/schemas/AccountLiabilityCreateRequest'
+    AccountBalance:
+      type: object
+      properties:
+        id:
+          type: string
+        account_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+        amount:
+          type: integer
+          nullable: true
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - account_id
+        - status
+        - created_at
+        - updated_at
+    AccountCardBrandInfo:
+      type: object
+      properties:
+        id:
+          type: string
+        card_product_id:
+          type: string
+        description:
+          type: string
+        name:
+          type: string
+        issuer:
+          type: string
+        network:
+          type: string
+        type:
+          type: string
+          enum:
+            - specific
+            - generic
+            - in_review
+        url:
+          type: string
+    AccountCardBrand:
+      type: object
+      properties:
+        id:
+          type: string
+        account_id:
+          type: string
+        brands:
+          type: array
+          items:
+            $ref: '#/components/schemas/AccountCardBrandInfo'
+        source:
+          type: string
+          enum:
+            - method
+            - network
+          nullable: true
+        status:
+          type: string
+          enum:
+            - completed
+            - in_progress
+            - failed
+        shared:
+          type: boolean
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - account_id
+        - brands
+        - status
+        - shared
+        - created_at
+        - updated_at
+    AccountPayoff:
+      type: object
+      properties:
+        id:
+          type: string
+        account_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+        amount:
+          type: integer
+          nullable: true
+        term:
+          type: integer
+          nullable: true
+        per_diem_amount:
+          type: integer
+          nullable: true
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - account_id
+        - status
+        - created_at
+        - updated_at
+    AccountSensitiveCreditCard:
+      type: object
+      properties:
+        number:
+          type: string
+          nullable: true
+        billing_zip_code:
+          type: string
+          nullable: true
+        exp_month:
+          type: string
+          nullable: true
+        exp_year:
+          type: string
+          nullable: true
+        cvv:
+          type: string
+          nullable: true
+    AccountSensitiveLoan:
+      type: object
+      properties:
+        number:
+          type: string
+    AccountSensitive:
+      type: object
+      properties:
+        id:
+          type: string
+        account_id:
+          type: string
+        type:
+          $ref: '#/components/schemas/AccountLiabilityType'
+        auto_loan:
+          $ref: '#/components/schemas/AccountSensitiveLoan'
+        credit_card:
+          $ref: '#/components/schemas/AccountSensitiveCreditCard'
+        mortgage:
+          $ref: '#/components/schemas/AccountSensitiveLoan'
+        personal_loan:
+          $ref: '#/components/schemas/AccountSensitiveLoan'
+        status:
+          type: string
+          enum:
+            - completed
+            - failed
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - account_id
+        - type
+        - status
+        - created_at
+        - updated_at
+    AccountSensitiveCreateRequest:
+      type: object
+      properties:
+        expand:
+          type: array
+          items:
+            type: string
+            enum:
+              - auto_loan.number
+              - mortgage.number
+              - personal_loan.number
+              - credit_card.number
+              - credit_card.billing_zip_code
+              - credit_card.exp_month
+              - credit_card.exp_year
+              - credit_card.cvv
+      required:
+        - expand
+    TransactionMerchant:
+      type: object
+      properties:
+        id:
+          type: string
+        logo:
+          type: string
+          nullable: true
+    AccountTransaction:
+      type: object
+      properties:
+        id:
+          type: string
+        account_id:
+          type: string
+        descriptor:
+          type: string
+        amount:
+          type: integer
+        auth_amount:
+          type: integer
+        currency_code:
+          type: string
+        transaction_amount:
+          type: integer
+        transaction_auth_amount:
+          type: integer
+        transaction_currency_code:
+          type: string
+        merchant:
+          allOf:
+            - $ref: '#/components/schemas/TransactionMerchant'
+          nullable: true
+        merchant_category_code:
+          type: string
+        status:
+          type: string
+          enum:
+            - pending
+            - posted
+            - voided
+        transacted_at:
+          type: string
+          format: date-time
+        posted_at:
+          type: string
+          format: date-time
+          nullable: true
+        voided_at:
+          type: string
+          format: date-time
+          nullable: true
+        original_txn_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - account_id
+        - descriptor
+        - amount
+        - status
+        - transacted_at
+        - created_at
+        - updated_at
+    AccountUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+        account_id:
+          type: string
+        source:
+          type: string
+          enum:
+            - direct
+            - snapshot
+        type:
+          $ref: '#/components/schemas/AccountLiabilityType'
+        auto_loan:
+          type: object
+        credit_card:
+          type: object
+        collection:
+          type: object
+        mortgage:
+          type: object
+        personal_loan:
+          type: object
+        student_loans:
+          type: object
+        credit_builder:
+          type: object
+        loan:
+          type: object
+        insurance:
+          type: object
+        medical:
+          type: object
+        utility:
+          type: object
+        data_as_of:
+          type: string
+          nullable: true
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - status
+        - account_id
+        - source
+        - type
+        - created_at
+        - updated_at
+    AccountAttributes:
+      type: object
+      properties:
+        id:
+          type: string
+        account_id:
+          type: string
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+        attributes:
+          type: object
+          nullable: true
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - account_id
+        - status
+        - created_at
+        - updated_at
+    AccountPaymentInstrument:
+      type: object
+      properties:
+        id:
+          type: string
+        account_id:
+          type: string
+        type:
+          type: string
+          enum:
+            - card
+            - network_token
+        network_token:
+          type: object
+          nullable: true
+        card:
+          type: object
+          nullable: true
+        chargeable:
+          type: boolean
+        status:
+          $ref: '#/components/schemas/ResourceStatus'
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - account_id
+        - type
+        - chargeable
+        - status
+        - created_at
+        - updated_at
+    AccountPaymentInstrumentCreateRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - card
+            - network_token
+      required:
+        - type
+    AccountVerificationSessionType:
+      type: string
+      enum:
+        - micro_deposits
+        - plaid
+        - mx
+        - teller
+        - standard
+        - instant
+        - pre_auth
+        - network
+    AccountVerificationSession:
+      type: object
+      properties:
+        id:
+          type: string
+        account_id:
+          type: string
+        status:
+          type: string
+          enum:
+            - pending
+            - in_progress
+            - verified
+            - failed
+        type:
+          $ref: '#/components/schemas/AccountVerificationSessionType'
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        plaid:
+          type: object
+          nullable: true
+        mx:
+          type: object
+          nullable: true
+        teller:
+          type: object
+          nullable: true
+        micro_deposits:
+          type: object
+          nullable: true
+        trusted_provisioner:
+          type: object
+          nullable: true
+        auto_verify:
+          type: object
+          nullable: true
+        standard:
+          type: object
+          nullable: true
+        instant:
+          type: object
+          nullable: true
+        pre_auth:
+          type: object
+          nullable: true
+        network:
+          type: object
+          nullable: true
+        three_ds:
+          type: object
+          nullable: true
+        issuer:
+          type: object
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - account_id
+        - status
+        - type
+        - created_at
+        - updated_at
+    AccountVerificationSessionCreateRequest:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/AccountVerificationSessionType'
+      required:
+        - type
+    AccountVerificationSessionUpdateRequest:
+      type: object
+      properties:
+        micro_deposits:
+          type: object
+        plaid:
+          type: object
+        mx:
+          type: object
+        teller:
+          type: object
+        standard:
+          type: object
+        instant:
+          type: object
+        pre_auth:
+          type: object
+        network:
+          type: object
+    AccountProduct:
+      type: object
+      properties:
+        name:
+          type: string
+        status:
+          type: string
+          enum:
+            - unavailable
+            - available
+            - restricted
+        status_error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        latest_request_id:
+          type: string
+          nullable: true
+        latest_successful_request_id:
+          type: string
+          nullable: true
+        is_subscribable:
+          type: boolean
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AccountSubscription:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+          enum:
+            - active
+            - inactive
+        payload:
+          type: object
+          nullable: true
+        latest_request_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+    AccountSubscriptionCreateRequest:
+      type: object
+      properties:
+        enroll:
+          type: string
+          enum:
+            - card_brand
+            - payment_instrument
+            - transaction
+            - update
+            - update.snapshot
+      required:
+        - enroll
+    AccountWithdrawConsentRequest:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - withdraw
+        reason:
+          type: string
+          enum:
+            - holder_withdrew_consent
+          nullable: true
+      required:
+        - type
+    PaymentStatus:
+      type: string
+      enum:
+        - pending
+        - canceled
+        - processing
+        - failed
+        - sent
+        - posted
+        - reversed
+        - reversal_required
+        - reversal_processing
+        - settled
+        - cashed
+    PaymentFundStatus:
+      type: string
+      enum:
+        - hold
+        - pending
+        - requested
+        - clearing
+        - failed
+        - sent
+        - posted
+        - unknown
+    PaymentType:
+      type: string
+      enum:
+        - standard
+        - clearing
+    PaymentFee:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - total
+            - markup
+        amount:
+          type: integer
+      required:
+        - type
+        - amount
+    Payment:
+      type: object
+      properties:
+        id:
+          type: string
+        reversal_id:
+          type: string
+          nullable: true
+        source_trace_id:
+          type: string
+          nullable: true
+        destination_trace_id:
+          type: string
+          nullable: true
+        source:
+          type: string
+        destination:
+          type: string
+        amount:
+          type: integer
+        description:
+          type: string
+        status:
+          $ref: '#/components/schemas/PaymentStatus'
+        fund_status:
+          $ref: '#/components/schemas/PaymentFundStatus'
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        metadata:
+          type: object
+          nullable: true
+        estimated_completion_date:
+          type: string
+          nullable: true
+        source_settlement_date:
+          type: string
+          nullable: true
+        destination_settlement_date:
+          type: string
+          nullable: true
+        source_status:
+          $ref: '#/components/schemas/PaymentStatus'
+        destination_status:
+          $ref: '#/components/schemas/PaymentStatus'
+        destination_payment_method:
+          type: string
+          enum:
+            - paper
+            - electronic
+          nullable: true
+        fee:
+          allOf:
+            - $ref: '#/components/schemas/PaymentFee'
+          nullable: true
+        type:
+          $ref: '#/components/schemas/PaymentType'
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - source
+        - destination
+        - amount
+        - description
+        - status
+        - type
+        - created_at
+        - updated_at
+    PaymentCreateRequest:
+      type: object
+      properties:
+        amount:
+          type: integer
+        source:
+          type: string
+        destination:
+          type: string
+        description:
+          type: string
+        metadata:
+          type: object
+        fee:
+          $ref: '#/components/schemas/PaymentFee'
+        dry_run:
+          type: boolean
+      required:
+        - amount
+        - source
+        - destination
+        - description
+    ReversalStatus:
+      type: string
+      enum:
+        - pending_approval
+        - pending
+        - processing
+        - sent
+        - failed
+    ReversalDirection:
+      type: string
+      enum:
+        - debit
+        - credit
+    Reversal:
+      type: object
+      properties:
+        id:
+          type: string
+        pmt_id:
+          type: string
+        target_account:
+          type: string
+        trace_id:
+          type: string
+          nullable: true
+        direction:
+          $ref: '#/components/schemas/ReversalDirection'
+        description:
+          type: string
+        amount:
+          type: integer
+        status:
+          $ref: '#/components/schemas/ReversalStatus'
+        error:
+          allOf:
+            - $ref: '#/components/schemas/ResourceError'
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - pmt_id
+        - target_account
+        - direction
+        - description
+        - amount
+        - status
+        - created_at
+        - updated_at
+    ReversalUpdateRequest:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/ReversalStatus'
+        description:
+          type: string
+          nullable: true
+      required:
+        - status
+    WebhookType:
+      type: string
+      enum:
+        - payment.create
+        - payment.update
+        - account.create
+        - account.update
+        - entity.update
+        - entity.create
+        - account_verification.create
+        - account_verification.update
+        - payment_reversal.create
+        - payment_reversal.update
+        - connection.create
+        - connection.update
+        - transaction.create
+        - transaction.update
+        - report.create
+        - report.update
+        - product.create
+        - product.update
+        - subscription.create
+        - subscription.update
+        - credit_score.create
+        - credit_score.update
+        - payoff.create
+        - payoff.update
+        - entity_verification_session.create
+        - entity_verification_session.update
+        - connect.create
+        - connect.update
+        - connect.available
+        - balance.create
+        - balance.update
+        - identity.create
+        - identity.update
+        - account_verification_session.create
+        - account_verification_session.update
+        - card_brand.create
+        - card_brand.update
+        - card_brand.available
+        - sensitive.create
+        - sensitive.update
+        - update.create
+        - update.update
+        - attribute.create
+        - attribute.update
+        - account.opened
+        - account.closed
+        - credit_score.increased
+        - credit_score.decreased
+    WebhookStatus:
+      type: string
+      enum:
+        - active
+        - disabled
+        - deleted
+        - requires_attention
+    Webhook:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          $ref: '#/components/schemas/WebhookType'
+        url:
+          type: string
+        metadata:
+          type: object
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+        expand_event:
+          type: boolean
+        error:
+          type: object
+          nullable: true
+        status:
+          type: string
+          nullable: true
+      required:
+        - id
+        - type
+        - url
+        - created_at
+        - updated_at
+        - expand_event
+    WebhookCreateRequest:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/WebhookType'
+        url:
+          type: string
+        auth_token:
+          type: string
+        hmac_secret:
+          type: string
+        metadata:
+          type: object
+        expand_event:
+          type: boolean
+      required:
+        - type
+        - url
+    WebhookUpdateRequest:
+      type: object
+      properties:
+        status:
+          type: string
+          enum:
+            - active
+            - disabled
+      required:
+        - status
+    ReportType:
+      type: string
+      enum:
+        - payments.created.current
+        - payments.created.previous
+        - payments.updated.current
+        - payments.updated.previous
+        - payments.created.previous_day
+        - payments.failed.previous_day
+        - ach.pull.upcoming
+        - ach.pull.previous
+        - ach.pull.nightly
+        - ach.reversals.nightly
+        - entities.created.previous_day
+    ReportStatus:
+      type: string
+      enum:
+        - processing
+        - completed
+    Report:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          $ref: '#/components/schemas/ReportType'
+        url:
+          type: string
+        status:
+          $ref: '#/components/schemas/ReportStatus'
+        metadata:
+          type: object
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - type
+        - url
+        - status
+        - created_at
+        - updated_at
+    ReportCreateRequest:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ReportType'
+        metadata:
+          type: object
+      required:
+        - type
+    MerchantProviderIds:
+      type: object
+      properties:
+        plaid:
+          type: array
+          items:
+            type: string
+        mx:
+          type: array
+          items:
+            type: string
+        finicity:
+          type: array
+          items:
+            type: string
+        dpp:
+          type: array
+          items:
+            type: string
+    Merchant:
+      type: object
+      properties:
+        id:
+          type: string
+        parent_name:
+          type: string
+        name:
+          type: string
+        logo:
+          type: string
+        type:
+          $ref: '#/components/schemas/AccountLiabilityType'
+        provider_ids:
+          $ref: '#/components/schemas/MerchantProviderIds'
+        is_temp:
+          type: boolean
+        account_number_formats:
+          type: array
+          items:
+            type: string
+      required:
+        - id
+        - parent_name
+        - name
+        - logo
+        - type
+        - provider_ids
+        - is_temp
+        - account_number_formats
+    EventResourceType:
+      type: string
+      enum:
+        - account
+        - credit_score
+        - attribute
+        - connect
+    EventDiff:
+      type: object
+      properties:
+        before:
+          type: object
+          nullable: true
+        after:
+          type: object
+          nullable: true
+    Event:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          $ref: '#/components/schemas/WebhookType'
+        resource_id:
+          type: string
+        resource_type:
+          $ref: '#/components/schemas/EventResourceType'
+        data:
+          type: object
+        diff:
+          $ref: '#/components/schemas/EventDiff'
+        updated_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - type
+        - resource_id
+        - resource_type
+        - data
+        - diff
+        - updated_at
+        - created_at
+    ElementType:
+      type: string
+      enum:
+        - connect
+        - balance_transfer
+    ElementToken:
+      type: object
+      properties:
+        element_token:
+          type: string
+      required:
+        - element_token
+    ElementUserEvent:
+      type: object
+      properties:
+        type:
+          type: string
+        timestamp:
+          type: string
+        metadata:
+          type: object
+          nullable: true
+    ElementResults:
+      type: object
+      properties:
+        authenticated:
+          type: boolean
+        cxn_id:
+          type: string
+          nullable: true
+        accounts:
+          type: array
+          items:
+            type: string
+        entity_id:
+          type: string
+          nullable: true
+        events:
+          type: array
+          items:
+            $ref: '#/components/schemas/ElementUserEvent'
+      required:
+        - authenticated
+        - accounts
+        - events
+    ElementTokenCreateRequest:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ElementType'
+        entity_id:
+          type: string
+        team_name:
+          type: string
+        team_logo:
+          type: string
+          nullable: true
+        team_icon:
+          type: string
+          nullable: true
+        connect:
+          type: object
+        balance_transfer:
+          type: object
+      required:
+        - type
+    OpalMode:
+      type: string
+      enum:
+        - identity_verification
+        - connect
+        - card_connect
+        - account_verification
+        - transactions
+    OpalToken:
+      type: object
+      properties:
+        token:
+          type: string
+        valid_until:
+          type: string
+        session_id:
+          type: string
+      required:
+        - token
+        - valid_until
+        - session_id
+    OpalTokenCreateRequest:
+      type: object
+      properties:
+        mode:
+          $ref: '#/components/schemas/OpalMode'
+        entity_id:
+          type: string
+        identity_verification:
+          type: object
+        connect:
+          type: object
+        card_connect:
+          type: object
+        account_verification:
+          type: object
+        transactions:
+          type: object
+      required:
+        - mode
+        - entity_id
+    SimulatePaymentUpdateRequest:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/PaymentStatus'
+        error_code:
+          type: integer
+          nullable: true
+      required:
+        - status
+    SimulateEntityConnectRequest:
+      type: object
+      properties:
+        behaviors:
+          type: array
+          items:
+            type: string
+            enum:
+              - new_credit_card_account
+              - new_auto_loan_account
+              - new_mortgage_account
+              - new_student_loan_account
+              - new_personal_loan_account
+      required:
+        - behaviors
+    SimulateEntityAttributesRequest:
+      type: object
+      properties:
+        behaviors:
+          type: array
+          items:
+            type: string
+            enum:
+              - new_soft_inquiry
+      required:
+        - behaviors
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+  headers:
+    IdemRequestId:
+      description: Unique request identifier for tracking and debugging
+      schema:
+        type: string
+    IdemStatus:
+      description: Idempotency status indicating how the request was processed
+      schema:
+        type: string
+        enum:
+          - stored
+          - bypassed
+          - replayed
+    PaginationPage:
+      description: Current page number
+      schema:
+        type: integer
+    PaginationPageCount:
+      description: Total number of pages available
+      schema:
+        type: integer
+    PaginationPageLimit:
+      description: Number of items per page
+      schema:
+        type: integer
+    PaginationTotalCount:
+      description: Total number of items across all pages
+      schema:
+        type: integer
+    PaginationPageCursorNext:
+      description: Cursor for fetching the next page
+      schema:
+        type: string
+    PaginationPageCursorPrev:
+      description: Cursor for fetching the previous page
+      schema:
+        type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@types/chai": "^4.3.1",
+        "@types/js-yaml": "^4.0.9",
         "@types/mocha": "^9.1.1",
         "@types/node": "^17.0.45",
         "chai": "^4.3.6",
@@ -23,6 +24,7 @@
         "eslint-config-airbnb": "^19.0.4",
         "eslint-plugin-flowtype": "^8.0.3",
         "eslint-plugin-import": "^2.26.0",
+        "js-yaml": "^4.1.0",
         "mocha": "^9.2.2",
         "rollup": "^2.70.2",
         "rollup-plugin-dts": "^4.2.1",
@@ -638,6 +640,13 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.1.tgz",
       "integrity": "sha512-/zPMqDkzSZ8t3VtxOa4KPq7uzzW978M9Tvh+j7GHKuo6k6GTLxPJ4J5gE5cjfJ26pnXst0N5Hax8Sr0T2Mi9zQ==",
       "dev": true
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://verdaccio.sofi.com/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "pretest": "./node_modules/.bin/tsc -p tsconfig-test.json",
     "test": "NODE_ENV=TEST ./node_modules/.bin/mocha --exit --timeout 100000 ./test-dist/test/index.js",
     "lint": "eslint src",
-    "lint:fix": "eslint src --fix"
+    "lint:fix": "eslint src --fix",
+    "generate:openapi": "npx ts-node --project scripts/tsconfig.scripts.json scripts/generate-openapi.ts",
+    "validate:openapi": "npx ts-node --project scripts/tsconfig.scripts.json scripts/validate-openapi.ts",
+    "lint:openapi": "npx @stoplight/spectral-cli lint openapi.yaml"
   },
   "repository": {
     "type": "git",
@@ -34,6 +37,7 @@
   "homepage": "https://github.com/MethodFi/method-node#readme",
   "devDependencies": {
     "@types/chai": "^4.3.1",
+    "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^9.1.1",
     "@types/node": "^17.0.45",
     "chai": "^4.3.6",
@@ -43,6 +47,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-import": "^2.26.0",
+    "js-yaml": "^4.1.0",
     "mocha": "^9.2.2",
     "rollup": "^2.70.2",
     "rollup-plugin-dts": "^4.2.1",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -21,7 +21,11 @@ npm run generate:openapi
 1. Parses all `types.ts` files in `src/resources/` to extract TypeScript interfaces
 2. Converts TypeScript types to OpenAPI schemas (handling nullables, arrays, enums, etc.)
 3. Generates path definitions for all API endpoints based on SDK resource structure
-4. Outputs both YAML and JSON versions of the specification
+4. Automatically adds `Idempotency-Key` header parameter to all POST, PUT, and PATCH operations
+5. Outputs both YAML and JSON versions of the specification
+
+**Idempotency Support:**
+The generator automatically includes the `Idempotency-Key` header parameter for all write operations (POST, PUT, PATCH). This ensures that generated clients expose idempotency as a first-class feature, preventing duplicate requests. The header is optional and follows the implementation in `src/resource.ts` where it's injected via request interceptors.
 
 ### validate-openapi.ts
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,10 +22,34 @@ npm run generate:openapi
 2. Converts TypeScript types to OpenAPI schemas (handling nullables, arrays, enums, etc.)
 3. Generates path definitions for all API endpoints based on SDK resource structure
 4. Automatically adds `Idempotency-Key` header parameter to all POST, PUT, and PATCH operations
-5. Outputs both YAML and JSON versions of the specification
+5. Automatically adds `Prefer` header parameter to all POST operations for async response patterns
+6. Enhances `expand` query parameters with enum constraints for type-safe field expansion
+7. Documents response headers for all operations (idempotency tracking and pagination metadata)
+8. Outputs both YAML and JSON versions of the specification
 
 **Idempotency Support:**
 The generator automatically includes the `Idempotency-Key` header parameter for all write operations (POST, PUT, PATCH). This ensures that generated clients expose idempotency as a first-class feature, preventing duplicate requests. The header is optional and follows the implementation in `src/resource.ts` where it's injected via request interceptors.
+
+**Prefer Header Support:**
+The generator automatically includes the `Prefer` header parameter for POST operations. This enables clients to control response behavior for long-running operations:
+- `respond-async` - Returns immediately with status='pending', requires polling for completion
+- `respond-sync` - Waits for operation to complete before returning (default behavior)
+
+Used by: Entity Connect, Entity creation, Payment creation, Webhook creation.
+
+**Expand Parameter Enhancement:**
+The generator adds enum constraints to `expand` query parameters, providing type-safe options in generated clients:
+- Entity operations: Can expand `connect`, `credit_score`, `attribute`, `vehicle`, `identity_latest_verification_session`, `phone_latest_verification_session`
+- Account operations: Can expand all product types (`payment`, `balance`, `sensitive`, `card_brand`, `payoff`, `update`, `attribute`, `transactions`, `payment_instrument`) plus `latest_verification_session`
+
+This ensures generated clients provide autocomplete and validation for expand values.
+
+**Response Headers:**
+All operations document response headers in the OpenAPI spec:
+- `idem-request-id`, `idem-status` - For request tracking and idempotency debugging
+- `pagination-*` headers - For list operations, providing pagination metadata (`pagination-page`, `pagination-page-count`, `pagination-page-limit`, `pagination-total-count`, `pagination-page-cursor-next`, `pagination-page-cursor-prev`)
+
+Generated clients can access these headers to implement proper pagination and debugging.
 
 ### validate-openapi.ts
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,103 @@
+# OpenAPI Specification Scripts
+
+This directory contains scripts for generating and validating the OpenAPI 3.0 specification from the Method Node.js SDK.
+
+## Scripts
+
+### generate-openapi.ts
+
+Generates an OpenAPI 3.0.3 specification by parsing the TypeScript SDK source files.
+
+**Usage:**
+```bash
+npm run generate:openapi
+```
+
+**Output:**
+- `openapi.yaml` - YAML format specification
+- `openapi.json` - JSON format specification
+
+**What it does:**
+1. Parses all `types.ts` files in `src/resources/` to extract TypeScript interfaces
+2. Converts TypeScript types to OpenAPI schemas (handling nullables, arrays, enums, etc.)
+3. Generates path definitions for all API endpoints based on SDK resource structure
+4. Outputs both YAML and JSON versions of the specification
+
+### validate-openapi.ts
+
+Validates the generated OpenAPI spec against the SDK source to ensure they match.
+
+**Usage:**
+```bash
+npm run validate:openapi
+```
+
+**What it validates:**
+- All expected API paths are present in the spec
+- HTTP methods match the SDK implementation
+- Schema properties match SDK interface definitions
+- Required vs optional field alignment
+
+## Linting
+
+The OpenAPI spec can be linted using Spectral for style and correctness:
+
+```bash
+npm run lint:openapi
+```
+
+This uses the `.spectral.yaml` configuration in the project root.
+
+## Workflow
+
+1. **Generate** the spec after SDK changes:
+   ```bash
+   npm run generate:openapi
+   ```
+
+2. **Validate** the spec matches the SDK:
+   ```bash
+   npm run validate:openapi
+   ```
+
+3. **Lint** for style issues:
+   ```bash
+   npm run lint:openapi
+   ```
+
+## Using the Generated Spec
+
+The generated OpenAPI specification can be used with code generators to create clients in other languages:
+
+```bash
+# Generate a Kotlin client
+npx @openapitools/openapi-generator-cli generate \
+  -i openapi.yaml \
+  -g kotlin \
+  -o ./generated/kotlin-client
+
+# Generate a Java client
+npx @openapitools/openapi-generator-cli generate \
+  -i openapi.yaml \
+  -g java \
+  -o ./generated/java-client
+```
+
+See [OpenAPI Generator](https://openapi-generator.tech/docs/generators) for all available generators.
+
+## Type Mapping
+
+| TypeScript | OpenAPI |
+|------------|---------|
+| `string` | `type: string` |
+| `number` | `type: number` |
+| `boolean` | `type: boolean` |
+| `string \| null` | `type: string, nullable: true` |
+| `T[]` | `type: array, items: {$ref: T}` |
+| `interface I{...}` | `$ref: '#/components/schemas/...'` |
+| `keyof typeof X` | `enum: [...]` |
+| Optional `prop?:` | Not in `required` array |
+
+## Configuration
+
+The scripts use their own TypeScript configuration in `tsconfig.scripts.json` to avoid conflicts with the main SDK build configuration.

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1776,7 +1776,7 @@ class OpenAPIGenerator {
         responseType: 'Entity',
         isList: true,
       }),
-      post: this.createOperation('createEntity', 'Create a new entity', ['Entities'], {
+      post: this.createOperation('createEntity', 'Create a new entity', ['Entities'], { httpMethod: 'post',
         requestBody: 'EntityCreateRequest',
         responseType: 'Entity',
       }),
@@ -1789,7 +1789,7 @@ class OpenAPIGenerator {
         queryParams: ['expand'],
         responseType: 'Entity',
       }),
-      put: this.createOperation('updateEntity', 'Update an entity', ['Entities'], {
+      put: this.createOperation('updateEntity', 'Update an entity', ['Entities'], { httpMethod: 'put',
         pathParams: ['ent_id'],
         requestBody: 'EntityUpdateRequest',
         responseType: 'Entity',
@@ -1798,7 +1798,7 @@ class OpenAPIGenerator {
 
     // /entities/{ent_id}/consent
     this.spec.paths['/entities/{ent_id}/consent'] = {
-      post: this.createOperation('withdrawEntityConsent', 'Withdraw entity consent', ['Entities'], {
+      post: this.createOperation('withdrawEntityConsent', 'Withdraw entity consent', ['Entities'], { httpMethod: 'post',
         pathParams: ['ent_id'],
         requestBody: 'EntityWithdrawConsentRequest',
         responseType: 'Entity',
@@ -1812,7 +1812,7 @@ class OpenAPIGenerator {
         responseType: 'EntityConnect',
         isList: true,
       }),
-      post: this.createOperation('createEntityConnect', 'Create entity connect', ['Entities - Connect'], {
+      post: this.createOperation('createEntityConnect', 'Create entity connect', ['Entities - Connect'], { httpMethod: 'post',
         pathParams: ['ent_id'],
         requestBody: 'EntityConnectCreateRequest',
         responseType: 'EntityConnect',
@@ -1834,7 +1834,7 @@ class OpenAPIGenerator {
         responseType: 'EntityCreditScores',
         isList: true,
       }),
-      post: this.createOperation('createEntityCreditScores', 'Create entity credit scores request', ['Entities - Credit Scores'], {
+      post: this.createOperation('createEntityCreditScores', 'Create entity credit scores request', ['Entities - Credit Scores'], { httpMethod: 'post',
         pathParams: ['ent_id'],
         responseType: 'EntityCreditScores',
       }),
@@ -1855,7 +1855,7 @@ class OpenAPIGenerator {
         responseType: 'EntityIdentity',
         isList: true,
       }),
-      post: this.createOperation('createEntityIdentity', 'Create entity identity request', ['Entities - Identities'], {
+      post: this.createOperation('createEntityIdentity', 'Create entity identity request', ['Entities - Identities'], { httpMethod: 'post',
         pathParams: ['ent_id'],
         responseType: 'EntityIdentity',
       }),
@@ -1876,7 +1876,7 @@ class OpenAPIGenerator {
         responseType: 'EntityAttributes',
         isList: true,
       }),
-      post: this.createOperation('createEntityAttributes', 'Create entity attributes request', ['Entities - Attributes'], {
+      post: this.createOperation('createEntityAttributes', 'Create entity attributes request', ['Entities - Attributes'], { httpMethod: 'post',
         pathParams: ['ent_id'],
         requestBody: 'EntityAttributesCreateRequest',
         responseType: 'EntityAttributes',
@@ -1898,7 +1898,7 @@ class OpenAPIGenerator {
         responseType: 'EntityVehicles',
         isList: true,
       }),
-      post: this.createOperation('createEntityVehicles', 'Create entity vehicles request', ['Entities - Vehicles'], {
+      post: this.createOperation('createEntityVehicles', 'Create entity vehicles request', ['Entities - Vehicles'], { httpMethod: 'post',
         pathParams: ['ent_id'],
         responseType: 'EntityVehicles',
       }),
@@ -1927,7 +1927,7 @@ class OpenAPIGenerator {
         responseType: 'EntitySubscription',
         isList: true,
       }),
-      post: this.createOperation('createEntitySubscription', 'Create entity subscription', ['Entities - Subscriptions'], {
+      post: this.createOperation('createEntitySubscription', 'Create entity subscription', ['Entities - Subscriptions'], { httpMethod: 'post',
         pathParams: ['ent_id'],
         requestBody: 'EntitySubscriptionCreateRequest',
         responseType: 'EntitySubscription',
@@ -1953,7 +1953,7 @@ class OpenAPIGenerator {
         responseType: 'EntityVerificationSession',
         isList: true,
       }),
-      post: this.createOperation('createEntityVerificationSession', 'Create entity verification session', ['Entities - Verification Sessions'], {
+      post: this.createOperation('createEntityVerificationSession', 'Create entity verification session', ['Entities - Verification Sessions'], { httpMethod: 'post',
         pathParams: ['ent_id'],
         requestBody: 'EntityVerificationSessionCreateRequest',
         responseType: 'EntityVerificationSession',
@@ -1966,7 +1966,7 @@ class OpenAPIGenerator {
         pathParams: ['ent_id', 'evf_id'],
         responseType: 'EntityVerificationSession',
       }),
-      put: this.createOperation('updateEntityVerificationSession', 'Update entity verification session', ['Entities - Verification Sessions'], {
+      put: this.createOperation('updateEntityVerificationSession', 'Update entity verification session', ['Entities - Verification Sessions'], { httpMethod: 'put',
         pathParams: ['ent_id', 'evf_id'],
         requestBody: 'EntityVerificationSessionUpdateRequest',
         responseType: 'EntityVerificationSession',
@@ -1982,7 +1982,7 @@ class OpenAPIGenerator {
         responseType: 'Account',
         isList: true,
       }),
-      post: this.createOperation('createAccount', 'Create a new account', ['Accounts'], {
+      post: this.createOperation('createAccount', 'Create a new account', ['Accounts'], { httpMethod: 'post',
         requestBody: 'AccountCreateRequest',
         responseType: 'Account',
       }),
@@ -1999,7 +1999,7 @@ class OpenAPIGenerator {
 
     // /accounts/{acc_id}/consent
     this.spec.paths['/accounts/{acc_id}/consent'] = {
-      post: this.createOperation('withdrawAccountConsent', 'Withdraw account consent', ['Accounts'], {
+      post: this.createOperation('withdrawAccountConsent', 'Withdraw account consent', ['Accounts'], { httpMethod: 'post',
         pathParams: ['acc_id'],
         requestBody: 'AccountWithdrawConsentRequest',
         responseType: 'Account',
@@ -2033,6 +2033,7 @@ class OpenAPIGenerator {
 
       if (subResource.hasCreate) {
         this.spec.paths[basePath].post = this.createOperation(`createAccount${subResource.name}`, `Create account ${subResource.path.slice(0, -1)}`, [tag], {
+          httpMethod: 'post',
           pathParams: ['acc_id'],
           requestBody: subResource.createRequest,
           responseType: subResource.schema,
@@ -2054,7 +2055,7 @@ class OpenAPIGenerator {
         responseType: 'AccountSubscription',
         isList: true,
       }),
-      post: this.createOperation('createAccountSubscription', 'Create account subscription', ['Accounts - Subscriptions'], {
+      post: this.createOperation('createAccountSubscription', 'Create account subscription', ['Accounts - Subscriptions'], { httpMethod: 'post',
         pathParams: ['acc_id'],
         requestBody: 'AccountSubscriptionCreateRequest',
         responseType: 'AccountSubscription',
@@ -2088,7 +2089,7 @@ class OpenAPIGenerator {
         responseType: 'AccountVerificationSession',
         isList: true,
       }),
-      post: this.createOperation('createAccountVerificationSession', 'Create account verification session', ['Accounts - Verification Sessions'], {
+      post: this.createOperation('createAccountVerificationSession', 'Create account verification session', ['Accounts - Verification Sessions'], { httpMethod: 'post',
         pathParams: ['acc_id'],
         requestBody: 'AccountVerificationSessionCreateRequest',
         responseType: 'AccountVerificationSession',
@@ -2100,7 +2101,7 @@ class OpenAPIGenerator {
         pathParams: ['acc_id', 'avf_id'],
         responseType: 'AccountVerificationSession',
       }),
-      put: this.createOperation('updateAccountVerificationSession', 'Update account verification session', ['Accounts - Verification Sessions'], {
+      put: this.createOperation('updateAccountVerificationSession', 'Update account verification session', ['Accounts - Verification Sessions'], { httpMethod: 'put',
         pathParams: ['acc_id', 'avf_id'],
         requestBody: 'AccountVerificationSessionUpdateRequest',
         responseType: 'AccountVerificationSession',
@@ -2116,7 +2117,7 @@ class OpenAPIGenerator {
         responseType: 'Payment',
         isList: true,
       }),
-      post: this.createOperation('createPayment', 'Create a new payment', ['Payments'], {
+      post: this.createOperation('createPayment', 'Create a new payment', ['Payments'], { httpMethod: 'post',
         requestBody: 'PaymentCreateRequest',
         responseType: 'Payment',
       }),
@@ -2149,7 +2150,7 @@ class OpenAPIGenerator {
         pathParams: ['pmt_id', 'rvs_id'],
         responseType: 'Reversal',
       }),
-      put: this.createOperation('updatePaymentReversal', 'Update payment reversal', ['Payments - Reversals'], {
+      put: this.createOperation('updatePaymentReversal', 'Update payment reversal', ['Payments - Reversals'], { httpMethod: 'put',
         pathParams: ['pmt_id', 'rvs_id'],
         requestBody: 'ReversalUpdateRequest',
         responseType: 'Reversal',
@@ -2164,7 +2165,7 @@ class OpenAPIGenerator {
         responseType: 'Webhook',
         isList: true,
       }),
-      post: this.createOperation('createWebhook', 'Create a new webhook', ['Webhooks'], {
+      post: this.createOperation('createWebhook', 'Create a new webhook', ['Webhooks'], { httpMethod: 'post',
         requestBody: 'WebhookCreateRequest',
         responseType: 'Webhook',
       }),
@@ -2176,7 +2177,7 @@ class OpenAPIGenerator {
         pathParams: ['whk_id'],
         responseType: 'Webhook',
       }),
-      patch: this.createOperation('updateWebhook', 'Update a webhook', ['Webhooks'], {
+      patch: this.createOperation('updateWebhook', 'Update a webhook', ['Webhooks'], { httpMethod: 'patch',
         pathParams: ['whk_id'],
         requestBody: 'WebhookUpdateRequest',
         responseType: 'Webhook',
@@ -2191,7 +2192,7 @@ class OpenAPIGenerator {
   private generateReportPaths(): void {
     // /reports
     this.spec.paths['/reports'] = {
-      post: this.createOperation('createReport', 'Create a new report', ['Reports'], {
+      post: this.createOperation('createReport', 'Create a new report', ['Reports'], { httpMethod: 'post',
         requestBody: 'ReportCreateRequest',
         responseType: 'Report',
       }),
@@ -2275,7 +2276,7 @@ class OpenAPIGenerator {
   private generateElementPaths(): void {
     // /elements/token
     this.spec.paths['/elements/token'] = {
-      post: this.createOperation('createElementToken', 'Create an element token', ['Elements'], {
+      post: this.createOperation('createElementToken', 'Create an element token', ['Elements'], { httpMethod: 'post',
         requestBody: 'ElementTokenCreateRequest',
         responseType: 'ElementToken',
       }),
@@ -2293,7 +2294,7 @@ class OpenAPIGenerator {
   private generateOpalPaths(): void {
     // /opal/token
     this.spec.paths['/opal/token'] = {
-      post: this.createOperation('createOpalToken', 'Create an opal token', ['Opal'], {
+      post: this.createOperation('createOpalToken', 'Create an opal token', ['Opal'], { httpMethod: 'post',
         requestBody: 'OpalTokenCreateRequest',
         responseType: 'OpalToken',
       }),
@@ -2303,7 +2304,7 @@ class OpenAPIGenerator {
   private generateSimulatePaths(): void {
     // /simulate/payments/{pmt_id}
     this.spec.paths['/simulate/payments/{pmt_id}'] = {
-      post: this.createOperation('simulatePaymentUpdate', 'Simulate payment status update', ['Simulate'], {
+      post: this.createOperation('simulatePaymentUpdate', 'Simulate payment status update', ['Simulate'], { httpMethod: 'post',
         pathParams: ['pmt_id'],
         requestBody: 'SimulatePaymentUpdateRequest',
         responseType: 'Payment',
@@ -2312,7 +2313,7 @@ class OpenAPIGenerator {
 
     // /simulate/accounts/{acc_id}/transactions
     this.spec.paths['/simulate/accounts/{acc_id}/transactions'] = {
-      post: this.createOperation('simulateAccountTransaction', 'Simulate account transaction', ['Simulate'], {
+      post: this.createOperation('simulateAccountTransaction', 'Simulate account transaction', ['Simulate'], { httpMethod: 'post',
         pathParams: ['acc_id'],
         responseType: 'AccountTransaction',
       }),
@@ -2320,7 +2321,7 @@ class OpenAPIGenerator {
 
     // /simulate/entities/{ent_id}/connect
     this.spec.paths['/simulate/entities/{ent_id}/connect'] = {
-      post: this.createOperation('simulateEntityConnect', 'Simulate entity connect', ['Simulate'], {
+      post: this.createOperation('simulateEntityConnect', 'Simulate entity connect', ['Simulate'], { httpMethod: 'post',
         pathParams: ['ent_id'],
         requestBody: 'SimulateEntityConnectRequest',
         responseType: 'EntityConnect',
@@ -2329,7 +2330,7 @@ class OpenAPIGenerator {
 
     // /simulate/entities/{ent_id}/credit_scores/{crs_id}
     this.spec.paths['/simulate/entities/{ent_id}/credit_scores/{crs_id}'] = {
-      post: this.createOperation('simulateEntityCreditScores', 'Simulate entity credit scores', ['Simulate'], {
+      post: this.createOperation('simulateEntityCreditScores', 'Simulate entity credit scores', ['Simulate'], { httpMethod: 'post',
         pathParams: ['ent_id', 'crs_id'],
         responseType: 'EntityCreditScores',
       }),
@@ -2337,7 +2338,7 @@ class OpenAPIGenerator {
 
     // /simulate/entities/{ent_id}/attributes/{atr_id}
     this.spec.paths['/simulate/entities/{ent_id}/attributes/{atr_id}'] = {
-      post: this.createOperation('simulateEntityAttributes', 'Simulate entity attributes', ['Simulate'], {
+      post: this.createOperation('simulateEntityAttributes', 'Simulate entity attributes', ['Simulate'], { httpMethod: 'post',
         pathParams: ['ent_id', 'atr_id'],
         requestBody: 'SimulateEntityAttributesRequest',
         responseType: 'EntityAttributes',
@@ -2346,7 +2347,7 @@ class OpenAPIGenerator {
 
     // /simulate/events
     this.spec.paths['/simulate/events'] = {
-      post: this.createOperation('simulateEvent', 'Simulate an event', ['Simulate'], {
+      post: this.createOperation('simulateEvent', 'Simulate an event', ['Simulate'], { httpMethod: 'post',
         responseType: 'Event',
       }),
     };
@@ -2363,6 +2364,7 @@ class OpenAPIGenerator {
       responseType: string;
       isList?: boolean;
       description?: string;
+      httpMethod?: 'get' | 'post' | 'put' | 'patch' | 'delete';
     }
   ): Operation {
     const operation: Operation = {
@@ -2408,6 +2410,18 @@ class OpenAPIGenerator {
           schema: { type: 'string' },
         });
       }
+    }
+
+    // Add Idempotency-Key header for write operations (POST, PUT, PATCH)
+    // This ensures idempotency support is exposed in generated clients
+    if (options.httpMethod && ['post', 'put', 'patch'].includes(options.httpMethod)) {
+      parameters.push({
+        name: 'Idempotency-Key',
+        in: 'header',
+        required: false,
+        schema: { type: 'string' },
+        description: 'Optional idempotency key to prevent duplicate requests. See https://docs.methodfi.com for more details.',
+      });
     }
 
     if (parameters.length > 0) {

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,0 +1,2480 @@
+/**
+ * OpenAPI Generator for Method SDK
+ *
+ * This script parses the TypeScript SDK source files and generates
+ * an OpenAPI 3.0 specification that can be used with code generators
+ * like openapi-generator to create clients in other languages.
+ */
+
+import * as ts from 'typescript';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+
+// ============================================================================
+// Types for OpenAPI generation
+// ============================================================================
+
+interface OpenAPISpec {
+  openapi: string;
+  info: {
+    title: string;
+    version: string;
+    description: string;
+    contact?: {
+      name?: string;
+      url?: string;
+      email?: string;
+    };
+  };
+  servers: Array<{ url: string; description: string }>;
+  tags?: Array<{ name: string; description: string }>;
+  security: Array<{ [key: string]: string[] }>;
+  paths: { [path: string]: PathItem };
+  components: {
+    schemas: { [name: string]: Schema };
+    securitySchemes: { [name: string]: SecurityScheme };
+  };
+}
+
+interface PathItem {
+  get?: Operation;
+  post?: Operation;
+  put?: Operation;
+  patch?: Operation;
+  delete?: Operation;
+}
+
+interface Operation {
+  operationId: string;
+  summary: string;
+  description: string;
+  tags: string[];
+  parameters?: Parameter[];
+  requestBody?: RequestBody;
+  responses: { [code: string]: Response };
+}
+
+interface Parameter {
+  name: string;
+  in: 'path' | 'query' | 'header';
+  required: boolean;
+  schema: Schema;
+  description?: string;
+}
+
+interface RequestBody {
+  required: boolean;
+  content: {
+    'application/json': {
+      schema: Schema;
+    };
+  };
+}
+
+interface Response {
+  description: string;
+  content?: {
+    [contentType: string]: {
+      schema: Schema;
+    };
+  };
+}
+
+interface Schema {
+  type?: string;
+  format?: string;
+  $ref?: string;
+  items?: Schema;
+  properties?: { [name: string]: Schema };
+  required?: string[];
+  nullable?: boolean;
+  enum?: (string | number)[];
+  additionalProperties?: boolean | Schema;
+  oneOf?: Schema[];
+  allOf?: Schema[];
+  description?: string;
+}
+
+interface SecurityScheme {
+  type: string;
+  scheme: string;
+}
+
+interface ParsedInterface {
+  name: string;
+  properties: ParsedProperty[];
+  extends?: string[];
+}
+
+interface ParsedProperty {
+  name: string;
+  type: string;
+  optional: boolean;
+  nullable: boolean;
+  description?: string;
+}
+
+interface ParsedEnum {
+  name: string;
+  values: string[];
+  valueType: 'keys' | 'values';
+}
+
+interface ResourceEndpoint {
+  path: string;
+  method: 'get' | 'post' | 'put' | 'patch' | 'delete';
+  operationId: string;
+  summary: string;
+  tags: string[];
+  pathParams: string[];
+  queryParams?: string;
+  requestBody?: string;
+  responseType: string;
+  isList?: boolean;
+}
+
+// ============================================================================
+// TypeScript Parser
+// ============================================================================
+
+class TypeScriptParser {
+  private program: ts.Program;
+  private checker: ts.TypeChecker;
+  private interfaces: Map<string, ParsedInterface> = new Map();
+  private enums: Map<string, ParsedEnum> = new Map();
+  private typeAliases: Map<string, string> = new Map();
+
+  constructor(private srcDir: string) {
+    const configPath = path.join(srcDir, '..', 'tsconfig.json');
+    const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+    const parsedConfig = ts.parseJsonConfigFileContent(
+      configFile.config,
+      ts.sys,
+      path.dirname(configPath)
+    );
+
+    this.program = ts.createProgram(parsedConfig.fileNames, parsedConfig.options);
+    this.checker = this.program.getTypeChecker();
+  }
+
+  parse(): void {
+    const sourceFiles = this.program.getSourceFiles().filter(
+      sf => sf.fileName.includes(this.srcDir) && !sf.fileName.includes('node_modules')
+    );
+
+    for (const sourceFile of sourceFiles) {
+      this.parseSourceFile(sourceFile);
+    }
+  }
+
+  private parseSourceFile(sourceFile: ts.SourceFile): void {
+    ts.forEachChild(sourceFile, node => {
+      if (ts.isInterfaceDeclaration(node)) {
+        this.parseInterface(node);
+      } else if (ts.isVariableStatement(node)) {
+        this.parseConstEnum(node);
+      } else if (ts.isTypeAliasDeclaration(node)) {
+        this.parseTypeAlias(node);
+      }
+    });
+  }
+
+  private parseInterface(node: ts.InterfaceDeclaration): void {
+    const name = node.name.text;
+    const properties: ParsedProperty[] = [];
+    const extendsClause: string[] = [];
+
+    if (node.heritageClauses) {
+      for (const clause of node.heritageClauses) {
+        for (const type of clause.types) {
+          if (ts.isIdentifier(type.expression)) {
+            extendsClause.push(type.expression.text);
+          }
+        }
+      }
+    }
+
+    for (const member of node.members) {
+      if (ts.isPropertySignature(member) && member.name) {
+        const propName = ts.isIdentifier(member.name) ? member.name.text : '';
+        const optional = !!member.questionToken;
+        const typeStr = member.type ? this.typeToString(member.type) : 'any';
+        const nullable = typeStr.includes('null');
+
+        properties.push({
+          name: propName,
+          type: typeStr.replace(' | null', '').replace('null | ', ''),
+          optional,
+          nullable,
+        });
+      }
+    }
+
+    this.interfaces.set(name, { name, properties, extends: extendsClause.length > 0 ? extendsClause : undefined });
+  }
+
+  private parseConstEnum(node: ts.VariableStatement): void {
+    for (const decl of node.declarationList.declarations) {
+      if (!ts.isIdentifier(decl.name)) continue;
+      const name = decl.name.text;
+
+      if (decl.initializer && ts.isObjectLiteralExpression(decl.initializer)) {
+        // Check if this is `as const`
+        const parent = decl.initializer.parent;
+        if (parent && ts.isAsExpression(parent)) {
+          const values: string[] = [];
+          for (const prop of decl.initializer.properties) {
+            if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name)) {
+              if (ts.isStringLiteral(prop.initializer)) {
+                values.push(prop.initializer.text);
+              } else {
+                values.push(prop.name.text);
+              }
+            }
+          }
+          if (values.length > 0) {
+            this.enums.set(name, { name, values, valueType: 'values' });
+          }
+        }
+      }
+    }
+  }
+
+  private parseTypeAlias(node: ts.TypeAliasDeclaration): void {
+    const name = node.name.text;
+    const typeStr = this.typeToString(node.type);
+    this.typeAliases.set(name, typeStr);
+  }
+
+  private typeToString(typeNode: ts.TypeNode): string {
+    if (ts.isTypeReferenceNode(typeNode)) {
+      if (ts.isIdentifier(typeNode.typeName)) {
+        return typeNode.typeName.text;
+      }
+      if (ts.isQualifiedName(typeNode.typeName)) {
+        return typeNode.typeName.right.text;
+      }
+    }
+
+    if (ts.isUnionTypeNode(typeNode)) {
+      return typeNode.types.map(t => this.typeToString(t)).join(' | ');
+    }
+
+    if (ts.isArrayTypeNode(typeNode)) {
+      return `${this.typeToString(typeNode.elementType)}[]`;
+    }
+
+    if (ts.isLiteralTypeNode(typeNode)) {
+      if (ts.isStringLiteral(typeNode.literal)) {
+        return `'${typeNode.literal.text}'`;
+      }
+      if (typeNode.literal.kind === ts.SyntaxKind.NullKeyword) {
+        return 'null';
+      }
+    }
+
+    if (ts.isTypeLiteralNode(typeNode)) {
+      return 'object';
+    }
+
+    if (typeNode.kind === ts.SyntaxKind.StringKeyword) return 'string';
+    if (typeNode.kind === ts.SyntaxKind.NumberKeyword) return 'number';
+    if (typeNode.kind === ts.SyntaxKind.BooleanKeyword) return 'boolean';
+    if (typeNode.kind === ts.SyntaxKind.AnyKeyword) return 'any';
+    if (typeNode.kind === ts.SyntaxKind.NullKeyword) return 'null';
+
+    return 'any';
+  }
+
+  getInterfaces(): Map<string, ParsedInterface> {
+    return this.interfaces;
+  }
+
+  getEnums(): Map<string, ParsedEnum> {
+    return this.enums;
+  }
+
+  getTypeAliases(): Map<string, string> {
+    return this.typeAliases;
+  }
+}
+
+// ============================================================================
+// OpenAPI Generator
+// ============================================================================
+
+class OpenAPIGenerator {
+  private spec: OpenAPISpec;
+  private interfaces: Map<string, ParsedInterface>;
+  private enums: Map<string, ParsedEnum>;
+  private typeAliases: Map<string, string>;
+  private generatedSchemas: Set<string> = new Set();
+
+  constructor(
+    interfaces: Map<string, ParsedInterface>,
+    enums: Map<string, ParsedEnum>,
+    typeAliases: Map<string, string>
+  ) {
+    this.interfaces = interfaces;
+    this.enums = enums;
+    this.typeAliases = typeAliases;
+    this.spec = this.initializeSpec();
+  }
+
+  private initializeSpec(): OpenAPISpec {
+    return {
+      openapi: '3.0.3',
+      info: {
+        title: 'Method API',
+        version: '2025-07-04',
+        description: 'Method Financial API - Node SDK Generated OpenAPI Specification',
+        contact: {
+          name: 'Method Financial',
+          url: 'https://methodfi.com',
+          email: 'support@methodfi.com',
+        },
+      },
+      servers: [
+        { url: 'https://production.methodfi.com', description: 'Production' },
+        { url: 'https://sandbox.methodfi.com', description: 'Sandbox' },
+        { url: 'https://dev.methodfi.com', description: 'Development' },
+      ],
+      tags: [
+        { name: 'Entities', description: 'Entity management endpoints' },
+        { name: 'Entities - Connect', description: 'Entity connection endpoints' },
+        { name: 'Entities - Credit Scores', description: 'Entity credit score endpoints' },
+        { name: 'Entities - Identities', description: 'Entity identity endpoints' },
+        { name: 'Entities - Attributes', description: 'Entity attribute endpoints' },
+        { name: 'Entities - Vehicles', description: 'Entity vehicle endpoints' },
+        { name: 'Entities - Products', description: 'Entity product endpoints' },
+        { name: 'Entities - Subscriptions', description: 'Entity subscription endpoints' },
+        { name: 'Entities - Verification Sessions', description: 'Entity verification session endpoints' },
+        { name: 'Accounts', description: 'Account management endpoints' },
+        { name: 'Accounts - Balances', description: 'Account balance endpoints' },
+        { name: 'Accounts - CardBrands', description: 'Account card brand endpoints' },
+        { name: 'Accounts - Payoffs', description: 'Account payoff endpoints' },
+        { name: 'Accounts - Sensitives', description: 'Account sensitive data endpoints' },
+        { name: 'Accounts - Transactions', description: 'Account transaction endpoints' },
+        { name: 'Accounts - Updates', description: 'Account update endpoints' },
+        { name: 'Accounts - Attributess', description: 'Account attribute endpoints' },
+        { name: 'Accounts - PaymentInstruments', description: 'Account payment instrument endpoints' },
+        { name: 'Accounts - Subscriptions', description: 'Account subscription endpoints' },
+        { name: 'Accounts - Products', description: 'Account product endpoints' },
+        { name: 'Accounts - Verification Sessions', description: 'Account verification session endpoints' },
+        { name: 'Payments', description: 'Payment management endpoints' },
+        { name: 'Payments - Reversals', description: 'Payment reversal endpoints' },
+        { name: 'Webhooks', description: 'Webhook management endpoints' },
+        { name: 'Reports', description: 'Report management endpoints' },
+        { name: 'Merchants', description: 'Merchant lookup endpoints' },
+        { name: 'Events', description: 'Event retrieval endpoints' },
+        { name: 'Elements', description: 'Element token endpoints' },
+        { name: 'Opal', description: 'Opal token endpoints' },
+        { name: 'Simulate', description: 'Simulation endpoints for testing' },
+      ],
+      security: [{ bearerAuth: [] }],
+      paths: {},
+      components: {
+        schemas: {},
+        securitySchemes: {
+          bearerAuth: {
+            type: 'http',
+            scheme: 'bearer',
+          },
+        },
+      },
+    };
+  }
+
+  // Helper to create a nullable reference using allOf (OpenAPI 3.0 compliant)
+  private nullableRef(ref: string): Schema {
+    return {
+      allOf: [{ $ref: ref }],
+      nullable: true,
+    };
+  }
+
+  // Helper to create a non-nullable reference
+  private ref(ref: string): Schema {
+    return { $ref: ref };
+  }
+
+  generate(): OpenAPISpec {
+    // Generate schemas for core types
+    this.generateCoreSchemas();
+
+    // Generate paths for all resources
+    this.generatePaths();
+
+    return this.spec;
+  }
+
+  private generateCoreSchemas(): void {
+    // Generate ResourceError schema
+    this.spec.components.schemas['ResourceError'] = {
+      type: 'object',
+      properties: {
+        type: { type: 'string' },
+        code: { type: 'integer' },
+        sub_type: { type: 'string' },
+        message: { type: 'string' },
+      },
+    };
+
+    // Generate common enums
+    this.spec.components.schemas['ResourceStatus'] = {
+      type: 'string',
+      enum: ['completed', 'in_progress', 'pending', 'failed'],
+    };
+
+    // Generate entity-related schemas
+    this.generateEntitySchemas();
+    this.generateAccountSchemas();
+    this.generatePaymentSchemas();
+    this.generateWebhookSchemas();
+    this.generateReportSchemas();
+    this.generateMerchantSchemas();
+    this.generateEventSchemas();
+    this.generateElementSchemas();
+    this.generateOpalSchemas();
+    this.generateSimulateSchemas();
+  }
+
+  private generateEntitySchemas(): void {
+    // EntityTypes enum
+    this.spec.components.schemas['EntityType'] = {
+      type: 'string',
+      enum: ['individual', 'corporation'],
+    };
+
+    // EntityStatuses enum
+    this.spec.components.schemas['EntityStatus'] = {
+      type: 'string',
+      enum: ['active', 'incomplete', 'disabled'],
+    };
+
+    // EntityAddress
+    this.spec.components.schemas['EntityAddress'] = {
+      type: 'object',
+      properties: {
+        line1: { type: 'string', nullable: true },
+        line2: { type: 'string', nullable: true },
+        city: { type: 'string', nullable: true },
+        state: { type: 'string', nullable: true },
+        zip: { type: 'string', nullable: true },
+      },
+    };
+
+    // EntityIndividual
+    this.spec.components.schemas['EntityIndividual'] = {
+      type: 'object',
+      properties: {
+        first_name: { type: 'string', nullable: true },
+        last_name: { type: 'string', nullable: true },
+        phone: { type: 'string', nullable: true },
+        email: { type: 'string', nullable: true },
+        dob: { type: 'string', nullable: true },
+        ssn: { type: 'string', nullable: true },
+        ssn_4: { type: 'string', nullable: true },
+      },
+    };
+
+    // EntityCorporationOwner
+    this.spec.components.schemas['EntityCorporationOwner'] = {
+      type: 'object',
+      properties: {
+        first_name: { type: 'string', nullable: true },
+        last_name: { type: 'string', nullable: true },
+        phone: { type: 'string', nullable: true },
+        email: { type: 'string', nullable: true },
+        dob: { type: 'string', nullable: true },
+        address: this.ref('#/components/schemas/EntityAddress'),
+      },
+    };
+
+    // EntityCorporation
+    this.spec.components.schemas['EntityCorporation'] = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', nullable: true },
+        dba: { type: 'string', nullable: true },
+        ein: { type: 'string', nullable: true },
+        owners: {
+          type: 'array',
+          items: this.ref('#/components/schemas/EntityCorporationOwner'),
+        },
+      },
+    };
+
+    // Entity
+    this.spec.components.schemas['Entity'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        type: this.nullableRef('#/components/schemas/EntityType'),
+        individual: this.nullableRef('#/components/schemas/EntityIndividual'),
+        corporation: this.nullableRef('#/components/schemas/EntityCorporation'),
+        address: this.ref('#/components/schemas/EntityAddress'),
+        status: this.ref('#/components/schemas/EntityStatus'),
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        metadata: { type: 'object', nullable: true },
+        products: { type: 'array', items: { type: 'string' } },
+        restricted_products: { type: 'array', items: { type: 'string' } },
+        subscriptions: { type: 'array', items: { type: 'string' } },
+        available_subscriptions: { type: 'array', items: { type: 'string' } },
+        restricted_subscriptions: { type: 'array', items: { type: 'string' } },
+        verification: { type: 'object', nullable: true },
+        connect: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/EntityConnect')], nullable: true },
+        credit_score: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/EntityCreditScores')], nullable: true },
+        attribute: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/EntityAttributes')], nullable: true },
+        vehicle: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/EntityVehicles')], nullable: true },
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'status', 'created_at', 'updated_at'],
+    };
+
+    // EntityCreateRequest
+    this.spec.components.schemas['EntityIndividualCreateRequest'] = {
+      type: 'object',
+      properties: {
+        type: { type: 'string', enum: ['individual'] },
+        individual: this.ref('#/components/schemas/EntityIndividual'),
+        address: this.ref('#/components/schemas/EntityAddress'),
+        metadata: { type: 'object', nullable: true },
+      },
+      required: ['type', 'individual'],
+    };
+
+    this.spec.components.schemas['EntityCorporationCreateRequest'] = {
+      type: 'object',
+      properties: {
+        type: { type: 'string', enum: ['corporation'] },
+        corporation: this.ref('#/components/schemas/EntityCorporation'),
+        address: this.ref('#/components/schemas/EntityAddress'),
+        metadata: { type: 'object', nullable: true },
+      },
+      required: ['type', 'corporation'],
+    };
+
+    this.spec.components.schemas['EntityCreateRequest'] = {
+      oneOf: [
+        this.ref('#/components/schemas/EntityIndividualCreateRequest'),
+        this.ref('#/components/schemas/EntityCorporationCreateRequest'),
+      ],
+    };
+
+    this.spec.components.schemas['EntityUpdateRequest'] = {
+      type: 'object',
+      properties: {
+        address: this.ref('#/components/schemas/EntityAddress'),
+        corporation: this.ref('#/components/schemas/EntityCorporation'),
+        individual: this.ref('#/components/schemas/EntityIndividual'),
+      },
+    };
+
+    // EntityConnect
+    this.spec.components.schemas['EntityConnect'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        entity_id: { type: 'string' },
+        status: this.ref('#/components/schemas/ResourceStatus'),
+        accounts: { type: 'array', items: { type: 'string' }, nullable: true },
+        requested_products: { type: 'array', items: { type: 'string' } },
+        requested_subscriptions: { type: 'array', items: { type: 'string' } },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'entity_id', 'status', 'created_at', 'updated_at'],
+    };
+
+    this.spec.components.schemas['EntityConnectCreateRequest'] = {
+      type: 'object',
+      properties: {
+        products: { type: 'array', items: { type: 'string' } },
+        subscriptions: { type: 'array', items: { type: 'string' } },
+      },
+    };
+
+    // EntityCreditScores
+    this.spec.components.schemas['CreditScoreModel'] = {
+      type: 'string',
+      enum: ['vantage_4', 'vantage_3'],
+    };
+
+    this.spec.components.schemas['CreditReportBureau'] = {
+      type: 'string',
+      enum: ['experian', 'equifax', 'transunion'],
+    };
+
+    this.spec.components.schemas['EntityCreditScoreFactor'] = {
+      type: 'object',
+      properties: {
+        code: { type: 'string' },
+        description: { type: 'string' },
+      },
+    };
+
+    this.spec.components.schemas['EntityCreditScoreItem'] = {
+      type: 'object',
+      properties: {
+        score: { type: 'integer' },
+        source: this.ref('#/components/schemas/CreditReportBureau'),
+        model: this.ref('#/components/schemas/CreditScoreModel'),
+        factors: { type: 'array', items: this.ref('#/components/schemas/EntityCreditScoreFactor') },
+        created_at: { type: 'string', format: 'date-time' },
+      },
+    };
+
+    this.spec.components.schemas['EntityCreditScores'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        entity_id: { type: 'string' },
+        status: this.ref('#/components/schemas/ResourceStatus'),
+        scores: { type: 'array', items: this.ref('#/components/schemas/EntityCreditScoreItem'), nullable: true },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'entity_id', 'status', 'created_at', 'updated_at'],
+    };
+
+    // EntityIdentity
+    this.spec.components.schemas['EntityIdentityType'] = {
+      type: 'object',
+      properties: {
+        first_name: { type: 'string', nullable: true },
+        last_name: { type: 'string', nullable: true },
+        phone: { type: 'string', nullable: true },
+        dob: { type: 'string', nullable: true },
+        address: { type: 'object', nullable: true },
+        ssn: { type: 'string', nullable: true },
+      },
+    };
+
+    this.spec.components.schemas['EntityIdentity'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        entity_id: { type: 'string' },
+        status: this.ref('#/components/schemas/ResourceStatus'),
+        identities: { type: 'array', items: this.ref('#/components/schemas/EntityIdentityType') },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'entity_id', 'status', 'identities', 'created_at', 'updated_at'],
+    };
+
+    // EntityAttributes
+    this.spec.components.schemas['CreditHealthAttributeRating'] = {
+      type: 'string',
+      enum: ['excellent', 'good', 'fair', 'needs_work'],
+    };
+
+    this.spec.components.schemas['CreditHealthAttribute'] = {
+      type: 'object',
+      properties: {
+        value: { type: 'number' },
+        rating: this.ref('#/components/schemas/CreditHealthAttributeRating'),
+        metadata: { type: 'object', nullable: true },
+      },
+    };
+
+    this.spec.components.schemas['EntityAttributesType'] = {
+      type: 'object',
+      properties: {
+        credit_health_credit_card_usage: this.ref('#/components/schemas/CreditHealthAttribute'),
+        credit_health_derogatory_marks: this.ref('#/components/schemas/CreditHealthAttribute'),
+        credit_health_hard_inquiries: this.ref('#/components/schemas/CreditHealthAttribute'),
+        credit_health_soft_inquiries: this.ref('#/components/schemas/CreditHealthAttribute'),
+        credit_health_total_accounts: this.ref('#/components/schemas/CreditHealthAttribute'),
+        credit_health_credit_age: this.ref('#/components/schemas/CreditHealthAttribute'),
+        credit_health_payment_history: this.ref('#/components/schemas/CreditHealthAttribute'),
+        credit_health_open_accounts: this.ref('#/components/schemas/CreditHealthAttribute'),
+        credit_health_entity_delinquent: this.ref('#/components/schemas/CreditHealthAttribute'),
+      },
+    };
+
+    this.spec.components.schemas['EntityAttributes'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        entity_id: { type: 'string' },
+        status: this.ref('#/components/schemas/ResourceStatus'),
+        attributes: this.nullableRef('#/components/schemas/EntityAttributesType'),
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'entity_id', 'status', 'created_at', 'updated_at'],
+    };
+
+    this.spec.components.schemas['EntityAttributesCreateRequest'] = {
+      type: 'object',
+      properties: {
+        attributes: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: [
+              'credit_health_credit_card_usage',
+              'credit_health_derogatory_marks',
+              'credit_health_hard_inquiries',
+              'credit_health_soft_inquiries',
+              'credit_health_total_accounts',
+              'credit_health_credit_age',
+              'credit_health_payment_history',
+              'credit_health_open_accounts',
+              'credit_health_entity_delinquent',
+            ],
+          },
+        },
+      },
+      required: ['attributes'],
+    };
+
+    // EntityVehicles
+    this.spec.components.schemas['EntityVehicleType'] = {
+      type: 'object',
+      properties: {
+        vin: { type: 'string', nullable: true },
+        year: { type: 'string', nullable: true },
+        make: { type: 'string', nullable: true },
+        model: { type: 'string', nullable: true },
+        series: { type: 'string', nullable: true },
+        major_color: { type: 'string', nullable: true },
+        style: { type: 'string', nullable: true },
+      },
+    };
+
+    this.spec.components.schemas['EntityVehicles'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        entity_id: { type: 'string' },
+        status: this.ref('#/components/schemas/ResourceStatus'),
+        vehicles: { type: 'array', items: this.ref('#/components/schemas/EntityVehicleType'), nullable: true },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'entity_id', 'status', 'created_at', 'updated_at'],
+    };
+
+    // EntityProduct
+    this.spec.components.schemas['EntityProductStatus'] = {
+      type: 'string',
+      enum: ['unavailable', 'available', 'restricted'],
+    };
+
+    this.spec.components.schemas['EntityProduct'] = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        status: this.ref('#/components/schemas/EntityProductStatus'),
+        status_error: this.nullableRef('#/components/schemas/ResourceError'),
+        latest_request_id: { type: 'string', nullable: true },
+        latest_successful_request_id: { type: 'string', nullable: true },
+        is_subscribable: { type: 'boolean' },
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+    };
+
+    this.spec.components.schemas['EntityProductListResponse'] = {
+      type: 'object',
+      properties: {
+        connect: this.ref('#/components/schemas/EntityProduct'),
+        credit_score: this.ref('#/components/schemas/EntityProduct'),
+        identity: this.ref('#/components/schemas/EntityProduct'),
+        attribute: this.ref('#/components/schemas/EntityProduct'),
+        vehicle: this.ref('#/components/schemas/EntityProduct'),
+        manual_connect: this.ref('#/components/schemas/EntityProduct'),
+      },
+    };
+
+    // EntitySubscription
+    this.spec.components.schemas['EntitySubscriptionStatus'] = {
+      type: 'string',
+      enum: ['active', 'inactive'],
+    };
+
+    this.spec.components.schemas['EntitySubscription'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        status: this.ref('#/components/schemas/EntitySubscriptionStatus'),
+        payload: { type: 'object', nullable: true },
+        latest_request_id: { type: 'string', nullable: true },
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+    };
+
+    this.spec.components.schemas['EntitySubscriptionCreateRequest'] = {
+      type: 'object',
+      properties: {
+        enroll: { type: 'string', enum: ['connect', 'credit_score', 'attribute'] },
+        payload: { type: 'object', nullable: true },
+      },
+      required: ['enroll'],
+    };
+
+    // EntityVerificationSession
+    this.spec.components.schemas['EntityVerificationSessionStatus'] = {
+      type: 'string',
+      enum: ['pending', 'in_progress', 'verified', 'failed'],
+    };
+
+    this.spec.components.schemas['EntityVerificationSessionType'] = {
+      type: 'string',
+      enum: ['phone', 'identity'],
+    };
+
+    this.spec.components.schemas['EntityVerificationSessionMethod'] = {
+      type: 'string',
+      enum: ['sms', 'sna', 'byo_sms', 'byo_kyc', 'kba', 'element', 'method_verified'],
+    };
+
+    this.spec.components.schemas['EntityVerificationSession'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        entity_id: { type: 'string' },
+        status: this.ref('#/components/schemas/EntityVerificationSessionStatus'),
+        type: this.ref('#/components/schemas/EntityVerificationSessionType'),
+        method: this.ref('#/components/schemas/EntityVerificationSessionMethod'),
+        sms: { type: 'object', nullable: true },
+        sna: { type: 'object', nullable: true },
+        byo_sms: { type: 'object', nullable: true },
+        byo_kyc: { type: 'object', nullable: true },
+        kba: { type: 'object', nullable: true },
+        element: { type: 'object', nullable: true },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'entity_id', 'status', 'type', 'method', 'created_at', 'updated_at'],
+    };
+
+    this.spec.components.schemas['EntityVerificationSessionCreateRequest'] = {
+      type: 'object',
+      properties: {
+        type: this.ref('#/components/schemas/EntityVerificationSessionType'),
+        method: this.ref('#/components/schemas/EntityVerificationSessionMethod'),
+        sms: { type: 'object' },
+        sna: { type: 'object' },
+        byo_sms: { type: 'object' },
+        byo_kyc: { type: 'object' },
+        kba: { type: 'object' },
+      },
+      required: ['type', 'method'],
+    };
+
+    this.spec.components.schemas['EntityVerificationSessionUpdateRequest'] = {
+      type: 'object',
+      properties: {
+        type: this.ref('#/components/schemas/EntityVerificationSessionType'),
+        method: this.ref('#/components/schemas/EntityVerificationSessionMethod'),
+        sms: { type: 'object' },
+        sna: { type: 'object' },
+        kba: { type: 'object' },
+      },
+      required: ['type', 'method'],
+    };
+
+    // EntityWithdrawConsent
+    this.spec.components.schemas['EntityWithdrawConsentRequest'] = {
+      type: 'object',
+      properties: {
+        type: { type: 'string', enum: ['withdraw'] },
+        reason: { type: 'string', enum: ['entity_withdrew_consent'], nullable: true },
+      },
+      required: ['type'],
+    };
+  }
+
+  private generateAccountSchemas(): void {
+    // AccountTypes
+    this.spec.components.schemas['AccountType'] = {
+      type: 'string',
+      enum: ['ach', 'liability'],
+    };
+
+    this.spec.components.schemas['AccountStatus'] = {
+      type: 'string',
+      enum: ['disabled', 'active', 'closed'],
+    };
+
+    this.spec.components.schemas['AccountLiabilityType'] = {
+      type: 'string',
+      enum: [
+        'auto_loan', 'bnpl', 'credit_builder', 'credit_card', 'collection',
+        'fintech', 'insurance', 'loan', 'medical', 'mortgage', 'personal_loan',
+        'student_loans', 'utility'
+      ],
+    };
+
+    this.spec.components.schemas['AccountOwnership'] = {
+      type: 'string',
+      enum: ['primary', 'authorized', 'joint', 'unknown'],
+    };
+
+    // AccountACH
+    this.spec.components.schemas['AccountACH'] = {
+      type: 'object',
+      properties: {
+        routing: { type: 'string' },
+        number: { type: 'string' },
+        type: { type: 'string', enum: ['savings', 'checking'] },
+      },
+      required: ['routing', 'number', 'type'],
+    };
+
+    // AccountLiability
+    this.spec.components.schemas['AccountLiability'] = {
+      type: 'object',
+      properties: {
+        mch_id: { type: 'string' },
+        mask: { type: 'string', nullable: true },
+        ownership: this.nullableRef('#/components/schemas/AccountOwnership'),
+        fingerprint: { type: 'string', nullable: true },
+        type: this.nullableRef('#/components/schemas/AccountLiabilityType'),
+        sub_type: { type: 'string', nullable: true },
+        name: { type: 'string', nullable: true },
+      },
+    };
+
+    // Account
+    this.spec.components.schemas['Account'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        holder_id: { type: 'string' },
+        status: this.ref('#/components/schemas/AccountStatus'),
+        type: this.nullableRef('#/components/schemas/AccountType'),
+        ach: this.nullableRef('#/components/schemas/AccountACH'),
+        liability: this.nullableRef('#/components/schemas/AccountLiability'),
+        products: { type: 'array', items: { type: 'string' } },
+        restricted_products: { type: 'array', items: { type: 'string' } },
+        subscriptions: { type: 'array', items: { type: 'string' } },
+        available_subscriptions: { type: 'array', items: { type: 'string' } },
+        restricted_subscriptions: { type: 'array', items: { type: 'string' } },
+        sensitive: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/AccountSensitive')], nullable: true },
+        balance: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/AccountBalance')], nullable: true },
+        card_brand: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/AccountCardBrand')], nullable: true },
+        payoff: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/AccountPayoff')], nullable: true },
+        transactions: { oneOf: [{ type: 'string' }, { type: 'array', items: this.ref('#/components/schemas/AccountTransaction') }], nullable: true },
+        update: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/AccountUpdate')], nullable: true },
+        attribute: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/AccountAttributes')], nullable: true },
+        payment_instrument: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/AccountPaymentInstrument')], nullable: true },
+        latest_verification_session: { oneOf: [{ type: 'string' }, this.ref('#/components/schemas/AccountVerificationSession')], nullable: true },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+        metadata: { type: 'object', nullable: true },
+      },
+      required: ['id', 'holder_id', 'status', 'products', 'restricted_products', 'created_at', 'updated_at'],
+    };
+
+    // Account create requests
+    this.spec.components.schemas['AccountACHCreateRequest'] = {
+      type: 'object',
+      properties: {
+        holder_id: { type: 'string' },
+        ach: this.ref('#/components/schemas/AccountACH'),
+        metadata: { type: 'object' },
+      },
+      required: ['holder_id', 'ach'],
+    };
+
+    this.spec.components.schemas['AccountLiabilityCreateRequest'] = {
+      type: 'object',
+      properties: {
+        holder_id: { type: 'string' },
+        liability: {
+          type: 'object',
+          properties: {
+            mch_id: { type: 'string' },
+            account_number: { type: 'string' },
+            number: { type: 'string' },
+          },
+          required: ['mch_id'],
+        },
+        metadata: { type: 'object' },
+      },
+      required: ['holder_id', 'liability'],
+    };
+
+    this.spec.components.schemas['AccountCreateRequest'] = {
+      oneOf: [
+        this.ref('#/components/schemas/AccountACHCreateRequest'),
+        this.ref('#/components/schemas/AccountLiabilityCreateRequest'),
+      ],
+    };
+
+    // AccountBalance
+    this.spec.components.schemas['AccountBalance'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        account_id: { type: 'string' },
+        status: this.ref('#/components/schemas/ResourceStatus'),
+        amount: { type: 'integer', nullable: true },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'account_id', 'status', 'created_at', 'updated_at'],
+    };
+
+    // AccountCardBrand
+    this.spec.components.schemas['AccountCardBrandInfo'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        card_product_id: { type: 'string' },
+        description: { type: 'string' },
+        name: { type: 'string' },
+        issuer: { type: 'string' },
+        network: { type: 'string' },
+        type: { type: 'string', enum: ['specific', 'generic', 'in_review'] },
+        url: { type: 'string' },
+      },
+    };
+
+    this.spec.components.schemas['AccountCardBrand'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        account_id: { type: 'string' },
+        brands: { type: 'array', items: this.ref('#/components/schemas/AccountCardBrandInfo') },
+        source: { type: 'string', enum: ['method', 'network'], nullable: true },
+        status: { type: 'string', enum: ['completed', 'in_progress', 'failed'] },
+        shared: { type: 'boolean' },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'account_id', 'brands', 'status', 'shared', 'created_at', 'updated_at'],
+    };
+
+    // AccountPayoff
+    this.spec.components.schemas['AccountPayoff'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        account_id: { type: 'string' },
+        status: this.ref('#/components/schemas/ResourceStatus'),
+        amount: { type: 'integer', nullable: true },
+        term: { type: 'integer', nullable: true },
+        per_diem_amount: { type: 'integer', nullable: true },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'account_id', 'status', 'created_at', 'updated_at'],
+    };
+
+    // AccountSensitive
+    this.spec.components.schemas['AccountSensitiveCreditCard'] = {
+      type: 'object',
+      properties: {
+        number: { type: 'string', nullable: true },
+        billing_zip_code: { type: 'string', nullable: true },
+        exp_month: { type: 'string', nullable: true },
+        exp_year: { type: 'string', nullable: true },
+        cvv: { type: 'string', nullable: true },
+      },
+    };
+
+    this.spec.components.schemas['AccountSensitiveLoan'] = {
+      type: 'object',
+      properties: {
+        number: { type: 'string' },
+      },
+    };
+
+    this.spec.components.schemas['AccountSensitive'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        account_id: { type: 'string' },
+        type: this.ref('#/components/schemas/AccountLiabilityType'),
+        auto_loan: this.ref('#/components/schemas/AccountSensitiveLoan'),
+        credit_card: this.ref('#/components/schemas/AccountSensitiveCreditCard'),
+        mortgage: this.ref('#/components/schemas/AccountSensitiveLoan'),
+        personal_loan: this.ref('#/components/schemas/AccountSensitiveLoan'),
+        status: { type: 'string', enum: ['completed', 'failed'] },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'account_id', 'type', 'status', 'created_at', 'updated_at'],
+    };
+
+    this.spec.components.schemas['AccountSensitiveCreateRequest'] = {
+      type: 'object',
+      properties: {
+        expand: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: [
+              'auto_loan.number', 'mortgage.number', 'personal_loan.number',
+              'credit_card.number', 'credit_card.billing_zip_code',
+              'credit_card.exp_month', 'credit_card.exp_year', 'credit_card.cvv'
+            ],
+          },
+        },
+      },
+      required: ['expand'],
+    };
+
+    // AccountTransaction
+    this.spec.components.schemas['TransactionMerchant'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        logo: { type: 'string', nullable: true },
+      },
+    };
+
+    this.spec.components.schemas['AccountTransaction'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        account_id: { type: 'string' },
+        descriptor: { type: 'string' },
+        amount: { type: 'integer' },
+        auth_amount: { type: 'integer' },
+        currency_code: { type: 'string' },
+        transaction_amount: { type: 'integer' },
+        transaction_auth_amount: { type: 'integer' },
+        transaction_currency_code: { type: 'string' },
+        merchant: this.nullableRef('#/components/schemas/TransactionMerchant'),
+        merchant_category_code: { type: 'string' },
+        status: { type: 'string', enum: ['pending', 'posted', 'voided'] },
+        transacted_at: { type: 'string', format: 'date-time' },
+        posted_at: { type: 'string', format: 'date-time', nullable: true },
+        voided_at: { type: 'string', format: 'date-time', nullable: true },
+        original_txn_id: { type: 'string', nullable: true },
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'account_id', 'descriptor', 'amount', 'status', 'transacted_at', 'created_at', 'updated_at'],
+    };
+
+    // AccountUpdate
+    this.spec.components.schemas['AccountUpdate'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        status: this.ref('#/components/schemas/ResourceStatus'),
+        account_id: { type: 'string' },
+        source: { type: 'string', enum: ['direct', 'snapshot'] },
+        type: this.ref('#/components/schemas/AccountLiabilityType'),
+        auto_loan: { type: 'object' },
+        credit_card: { type: 'object' },
+        collection: { type: 'object' },
+        mortgage: { type: 'object' },
+        personal_loan: { type: 'object' },
+        student_loans: { type: 'object' },
+        credit_builder: { type: 'object' },
+        loan: { type: 'object' },
+        insurance: { type: 'object' },
+        medical: { type: 'object' },
+        utility: { type: 'object' },
+        data_as_of: { type: 'string', nullable: true },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'status', 'account_id', 'source', 'type', 'created_at', 'updated_at'],
+    };
+
+    // AccountAttributes
+    this.spec.components.schemas['AccountAttributes'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        account_id: { type: 'string' },
+        status: this.ref('#/components/schemas/ResourceStatus'),
+        attributes: { type: 'object', nullable: true },
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'account_id', 'status', 'created_at', 'updated_at'],
+    };
+
+    // AccountPaymentInstrument
+    this.spec.components.schemas['AccountPaymentInstrument'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        account_id: { type: 'string' },
+        type: { type: 'string', enum: ['card', 'network_token'] },
+        network_token: { type: 'object', nullable: true },
+        card: { type: 'object', nullable: true },
+        chargeable: { type: 'boolean' },
+        status: this.ref('#/components/schemas/ResourceStatus'),
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'account_id', 'type', 'chargeable', 'status', 'created_at', 'updated_at'],
+    };
+
+    this.spec.components.schemas['AccountPaymentInstrumentCreateRequest'] = {
+      type: 'object',
+      properties: {
+        type: { type: 'string', enum: ['card', 'network_token'] },
+      },
+      required: ['type'],
+    };
+
+    // AccountVerificationSession
+    this.spec.components.schemas['AccountVerificationSessionType'] = {
+      type: 'string',
+      enum: ['micro_deposits', 'plaid', 'mx', 'teller', 'standard', 'instant', 'pre_auth', 'network'],
+    };
+
+    this.spec.components.schemas['AccountVerificationSession'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        account_id: { type: 'string' },
+        status: { type: 'string', enum: ['pending', 'in_progress', 'verified', 'failed'] },
+        type: this.ref('#/components/schemas/AccountVerificationSessionType'),
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        plaid: { type: 'object', nullable: true },
+        mx: { type: 'object', nullable: true },
+        teller: { type: 'object', nullable: true },
+        micro_deposits: { type: 'object', nullable: true },
+        trusted_provisioner: { type: 'object', nullable: true },
+        auto_verify: { type: 'object', nullable: true },
+        standard: { type: 'object', nullable: true },
+        instant: { type: 'object', nullable: true },
+        pre_auth: { type: 'object', nullable: true },
+        network: { type: 'object', nullable: true },
+        three_ds: { type: 'object', nullable: true },
+        issuer: { type: 'object', nullable: true },
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'account_id', 'status', 'type', 'created_at', 'updated_at'],
+    };
+
+    this.spec.components.schemas['AccountVerificationSessionCreateRequest'] = {
+      type: 'object',
+      properties: {
+        type: this.ref('#/components/schemas/AccountVerificationSessionType'),
+      },
+      required: ['type'],
+    };
+
+    this.spec.components.schemas['AccountVerificationSessionUpdateRequest'] = {
+      type: 'object',
+      properties: {
+        micro_deposits: { type: 'object' },
+        plaid: { type: 'object' },
+        mx: { type: 'object' },
+        teller: { type: 'object' },
+        standard: { type: 'object' },
+        instant: { type: 'object' },
+        pre_auth: { type: 'object' },
+        network: { type: 'object' },
+      },
+    };
+
+    // Account Product and Subscription
+    this.spec.components.schemas['AccountProduct'] = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        status: { type: 'string', enum: ['unavailable', 'available', 'restricted'] },
+        status_error: this.nullableRef('#/components/schemas/ResourceError'),
+        latest_request_id: { type: 'string', nullable: true },
+        latest_successful_request_id: { type: 'string', nullable: true },
+        is_subscribable: { type: 'boolean' },
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+    };
+
+    this.spec.components.schemas['AccountSubscription'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        status: { type: 'string', enum: ['active', 'inactive'] },
+        payload: { type: 'object', nullable: true },
+        latest_request_id: { type: 'string', nullable: true },
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+    };
+
+    this.spec.components.schemas['AccountSubscriptionCreateRequest'] = {
+      type: 'object',
+      properties: {
+        enroll: { type: 'string', enum: ['card_brand', 'payment_instrument', 'transaction', 'update', 'update.snapshot'] },
+      },
+      required: ['enroll'],
+    };
+
+    // AccountWithdrawConsent
+    this.spec.components.schemas['AccountWithdrawConsentRequest'] = {
+      type: 'object',
+      properties: {
+        type: { type: 'string', enum: ['withdraw'] },
+        reason: { type: 'string', enum: ['holder_withdrew_consent'], nullable: true },
+      },
+      required: ['type'],
+    };
+  }
+
+  private generatePaymentSchemas(): void {
+    // PaymentStatus
+    this.spec.components.schemas['PaymentStatus'] = {
+      type: 'string',
+      enum: [
+        'pending', 'canceled', 'processing', 'failed', 'sent', 'posted',
+        'reversed', 'reversal_required', 'reversal_processing', 'settled', 'cashed'
+      ],
+    };
+
+    this.spec.components.schemas['PaymentFundStatus'] = {
+      type: 'string',
+      enum: ['hold', 'pending', 'requested', 'clearing', 'failed', 'sent', 'posted', 'unknown'],
+    };
+
+    this.spec.components.schemas['PaymentType'] = {
+      type: 'string',
+      enum: ['standard', 'clearing'],
+    };
+
+    // PaymentFee
+    this.spec.components.schemas['PaymentFee'] = {
+      type: 'object',
+      properties: {
+        type: { type: 'string', enum: ['total', 'markup'] },
+        amount: { type: 'integer' },
+      },
+      required: ['type', 'amount'],
+    };
+
+    // Payment
+    this.spec.components.schemas['Payment'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        reversal_id: { type: 'string', nullable: true },
+        source_trace_id: { type: 'string', nullable: true },
+        destination_trace_id: { type: 'string', nullable: true },
+        source: { type: 'string' },
+        destination: { type: 'string' },
+        amount: { type: 'integer' },
+        description: { type: 'string' },
+        status: this.ref('#/components/schemas/PaymentStatus'),
+        fund_status: this.ref('#/components/schemas/PaymentFundStatus'),
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        metadata: { type: 'object', nullable: true },
+        estimated_completion_date: { type: 'string', nullable: true },
+        source_settlement_date: { type: 'string', nullable: true },
+        destination_settlement_date: { type: 'string', nullable: true },
+        source_status: this.ref('#/components/schemas/PaymentStatus'),
+        destination_status: this.ref('#/components/schemas/PaymentStatus'),
+        destination_payment_method: { type: 'string', enum: ['paper', 'electronic'], nullable: true },
+        fee: this.nullableRef('#/components/schemas/PaymentFee'),
+        type: this.ref('#/components/schemas/PaymentType'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'source', 'destination', 'amount', 'description', 'status', 'type', 'created_at', 'updated_at'],
+    };
+
+    // PaymentCreateRequest
+    this.spec.components.schemas['PaymentCreateRequest'] = {
+      type: 'object',
+      properties: {
+        amount: { type: 'integer' },
+        source: { type: 'string' },
+        destination: { type: 'string' },
+        description: { type: 'string' },
+        metadata: { type: 'object' },
+        fee: this.ref('#/components/schemas/PaymentFee'),
+        dry_run: { type: 'boolean' },
+      },
+      required: ['amount', 'source', 'destination', 'description'],
+    };
+
+    // Reversal
+    this.spec.components.schemas['ReversalStatus'] = {
+      type: 'string',
+      enum: ['pending_approval', 'pending', 'processing', 'sent', 'failed'],
+    };
+
+    this.spec.components.schemas['ReversalDirection'] = {
+      type: 'string',
+      enum: ['debit', 'credit'],
+    };
+
+    this.spec.components.schemas['Reversal'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        pmt_id: { type: 'string' },
+        target_account: { type: 'string' },
+        trace_id: { type: 'string', nullable: true },
+        direction: this.ref('#/components/schemas/ReversalDirection'),
+        description: { type: 'string' },
+        amount: { type: 'integer' },
+        status: this.ref('#/components/schemas/ReversalStatus'),
+        error: this.nullableRef('#/components/schemas/ResourceError'),
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'pmt_id', 'target_account', 'direction', 'description', 'amount', 'status', 'created_at', 'updated_at'],
+    };
+
+    this.spec.components.schemas['ReversalUpdateRequest'] = {
+      type: 'object',
+      properties: {
+        status: this.ref('#/components/schemas/ReversalStatus'),
+        description: { type: 'string', nullable: true },
+      },
+      required: ['status'],
+    };
+  }
+
+  private generateWebhookSchemas(): void {
+    this.spec.components.schemas['WebhookType'] = {
+      type: 'string',
+      enum: [
+        'payment.create', 'payment.update', 'account.create', 'account.update',
+        'entity.update', 'entity.create', 'account_verification.create', 'account_verification.update',
+        'payment_reversal.create', 'payment_reversal.update', 'connection.create', 'connection.update',
+        'transaction.create', 'transaction.update', 'report.create', 'report.update',
+        'product.create', 'product.update', 'subscription.create', 'subscription.update',
+        'credit_score.create', 'credit_score.update', 'payoff.create', 'payoff.update',
+        'entity_verification_session.create', 'entity_verification_session.update',
+        'connect.create', 'connect.update', 'connect.available',
+        'balance.create', 'balance.update', 'identity.create', 'identity.update',
+        'account_verification_session.create', 'account_verification_session.update',
+        'card_brand.create', 'card_brand.update', 'card_brand.available',
+        'sensitive.create', 'sensitive.update', 'update.create', 'update.update',
+        'attribute.create', 'attribute.update', 'account.opened', 'account.closed',
+        'credit_score.increased', 'credit_score.decreased',
+      ],
+    };
+
+    this.spec.components.schemas['WebhookStatus'] = {
+      type: 'string',
+      enum: ['active', 'disabled', 'deleted', 'requires_attention'],
+    };
+
+    this.spec.components.schemas['Webhook'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        type: this.ref('#/components/schemas/WebhookType'),
+        url: { type: 'string' },
+        metadata: { type: 'object', nullable: true },
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+        expand_event: { type: 'boolean' },
+        error: { type: 'object', nullable: true },
+        status: { type: 'string', nullable: true },
+      },
+      required: ['id', 'type', 'url', 'created_at', 'updated_at', 'expand_event'],
+    };
+
+    this.spec.components.schemas['WebhookCreateRequest'] = {
+      type: 'object',
+      properties: {
+        type: this.ref('#/components/schemas/WebhookType'),
+        url: { type: 'string' },
+        auth_token: { type: 'string' },
+        hmac_secret: { type: 'string' },
+        metadata: { type: 'object' },
+        expand_event: { type: 'boolean' },
+      },
+      required: ['type', 'url'],
+    };
+
+    this.spec.components.schemas['WebhookUpdateRequest'] = {
+      type: 'object',
+      properties: {
+        status: { type: 'string', enum: ['active', 'disabled'] },
+      },
+      required: ['status'],
+    };
+  }
+
+  private generateReportSchemas(): void {
+    this.spec.components.schemas['ReportType'] = {
+      type: 'string',
+      enum: [
+        'payments.created.current', 'payments.created.previous',
+        'payments.updated.current', 'payments.updated.previous',
+        'payments.created.previous_day', 'payments.failed.previous_day',
+        'ach.pull.upcoming', 'ach.pull.previous', 'ach.pull.nightly',
+        'ach.reversals.nightly', 'entities.created.previous_day',
+      ],
+    };
+
+    this.spec.components.schemas['ReportStatus'] = {
+      type: 'string',
+      enum: ['processing', 'completed'],
+    };
+
+    this.spec.components.schemas['Report'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        type: this.ref('#/components/schemas/ReportType'),
+        url: { type: 'string' },
+        status: this.ref('#/components/schemas/ReportStatus'),
+        metadata: { type: 'object', nullable: true },
+        created_at: { type: 'string', format: 'date-time' },
+        updated_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'type', 'url', 'status', 'created_at', 'updated_at'],
+    };
+
+    this.spec.components.schemas['ReportCreateRequest'] = {
+      type: 'object',
+      properties: {
+        type: this.ref('#/components/schemas/ReportType'),
+        metadata: { type: 'object' },
+      },
+      required: ['type'],
+    };
+  }
+
+  private generateMerchantSchemas(): void {
+    this.spec.components.schemas['MerchantProviderIds'] = {
+      type: 'object',
+      properties: {
+        plaid: { type: 'array', items: { type: 'string' } },
+        mx: { type: 'array', items: { type: 'string' } },
+        finicity: { type: 'array', items: { type: 'string' } },
+        dpp: { type: 'array', items: { type: 'string' } },
+      },
+    };
+
+    this.spec.components.schemas['Merchant'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        parent_name: { type: 'string' },
+        name: { type: 'string' },
+        logo: { type: 'string' },
+        type: this.ref('#/components/schemas/AccountLiabilityType'),
+        provider_ids: this.ref('#/components/schemas/MerchantProviderIds'),
+        is_temp: { type: 'boolean' },
+        account_number_formats: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['id', 'parent_name', 'name', 'logo', 'type', 'provider_ids', 'is_temp', 'account_number_formats'],
+    };
+  }
+
+  private generateEventSchemas(): void {
+    this.spec.components.schemas['EventResourceType'] = {
+      type: 'string',
+      enum: ['account', 'credit_score', 'attribute', 'connect'],
+    };
+
+    this.spec.components.schemas['EventDiff'] = {
+      type: 'object',
+      properties: {
+        before: { type: 'object', nullable: true },
+        after: { type: 'object', nullable: true },
+      },
+    };
+
+    this.spec.components.schemas['Event'] = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        type: this.ref('#/components/schemas/WebhookType'),
+        resource_id: { type: 'string' },
+        resource_type: this.ref('#/components/schemas/EventResourceType'),
+        data: { type: 'object' },
+        diff: this.ref('#/components/schemas/EventDiff'),
+        updated_at: { type: 'string', format: 'date-time' },
+        created_at: { type: 'string', format: 'date-time' },
+      },
+      required: ['id', 'type', 'resource_id', 'resource_type', 'data', 'diff', 'updated_at', 'created_at'],
+    };
+  }
+
+  private generateElementSchemas(): void {
+    this.spec.components.schemas['ElementType'] = {
+      type: 'string',
+      enum: ['connect', 'balance_transfer'],
+    };
+
+    this.spec.components.schemas['ElementToken'] = {
+      type: 'object',
+      properties: {
+        element_token: { type: 'string' },
+      },
+      required: ['element_token'],
+    };
+
+    this.spec.components.schemas['ElementUserEvent'] = {
+      type: 'object',
+      properties: {
+        type: { type: 'string' },
+        timestamp: { type: 'string' },
+        metadata: { type: 'object', nullable: true },
+      },
+    };
+
+    this.spec.components.schemas['ElementResults'] = {
+      type: 'object',
+      properties: {
+        authenticated: { type: 'boolean' },
+        cxn_id: { type: 'string', nullable: true },
+        accounts: { type: 'array', items: { type: 'string' } },
+        entity_id: { type: 'string', nullable: true },
+        events: { type: 'array', items: this.ref('#/components/schemas/ElementUserEvent') },
+      },
+      required: ['authenticated', 'accounts', 'events'],
+    };
+
+    this.spec.components.schemas['ElementTokenCreateRequest'] = {
+      type: 'object',
+      properties: {
+        type: this.ref('#/components/schemas/ElementType'),
+        entity_id: { type: 'string' },
+        team_name: { type: 'string' },
+        team_logo: { type: 'string', nullable: true },
+        team_icon: { type: 'string', nullable: true },
+        connect: { type: 'object' },
+        balance_transfer: { type: 'object' },
+      },
+      required: ['type'],
+    };
+  }
+
+  private generateOpalSchemas(): void {
+    this.spec.components.schemas['OpalMode'] = {
+      type: 'string',
+      enum: ['identity_verification', 'connect', 'card_connect', 'account_verification', 'transactions'],
+    };
+
+    this.spec.components.schemas['OpalToken'] = {
+      type: 'object',
+      properties: {
+        token: { type: 'string' },
+        valid_until: { type: 'string' },
+        session_id: { type: 'string' },
+      },
+      required: ['token', 'valid_until', 'session_id'],
+    };
+
+    this.spec.components.schemas['OpalTokenCreateRequest'] = {
+      type: 'object',
+      properties: {
+        mode: this.ref('#/components/schemas/OpalMode'),
+        entity_id: { type: 'string' },
+        identity_verification: { type: 'object' },
+        connect: { type: 'object' },
+        card_connect: { type: 'object' },
+        account_verification: { type: 'object' },
+        transactions: { type: 'object' },
+      },
+      required: ['mode', 'entity_id'],
+    };
+  }
+
+  private generateSimulateSchemas(): void {
+    this.spec.components.schemas['SimulatePaymentUpdateRequest'] = {
+      type: 'object',
+      properties: {
+        status: this.ref('#/components/schemas/PaymentStatus'),
+        error_code: { type: 'integer', nullable: true },
+      },
+      required: ['status'],
+    };
+
+    this.spec.components.schemas['SimulateEntityConnectRequest'] = {
+      type: 'object',
+      properties: {
+        behaviors: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['new_credit_card_account', 'new_auto_loan_account', 'new_mortgage_account', 'new_student_loan_account', 'new_personal_loan_account'],
+          },
+        },
+      },
+      required: ['behaviors'],
+    };
+
+    this.spec.components.schemas['SimulateEntityAttributesRequest'] = {
+      type: 'object',
+      properties: {
+        behaviors: {
+          type: 'array',
+          items: {
+            type: 'string',
+            enum: ['new_soft_inquiry'],
+          },
+        },
+      },
+      required: ['behaviors'],
+    };
+  }
+
+  private generatePaths(): void {
+    // Entities
+    this.generateEntityPaths();
+
+    // Accounts
+    this.generateAccountPaths();
+
+    // Payments
+    this.generatePaymentPaths();
+
+    // Webhooks
+    this.generateWebhookPaths();
+
+    // Reports
+    this.generateReportPaths();
+
+    // Merchants
+    this.generateMerchantPaths();
+
+    // Events
+    this.generateEventPaths();
+
+    // Elements
+    this.generateElementPaths();
+
+    // Opal
+    this.generateOpalPaths();
+
+    // Simulate
+    this.generateSimulatePaths();
+  }
+
+  private generateEntityPaths(): void {
+    // /entities
+    this.spec.paths['/entities'] = {
+      get: this.createOperation('listEntities', 'List all entities', ['Entities'], {
+        queryParams: ['from_date', 'to_date', 'page', 'page_limit', 'page_cursor', 'status', 'type', 'expand'],
+        responseType: 'Entity',
+        isList: true,
+      }),
+      post: this.createOperation('createEntity', 'Create a new entity', ['Entities'], {
+        requestBody: 'EntityCreateRequest',
+        responseType: 'Entity',
+      }),
+    };
+
+    // /entities/{ent_id}
+    this.spec.paths['/entities/{ent_id}'] = {
+      get: this.createOperation('retrieveEntity', 'Retrieve an entity', ['Entities'], {
+        pathParams: ['ent_id'],
+        queryParams: ['expand'],
+        responseType: 'Entity',
+      }),
+      put: this.createOperation('updateEntity', 'Update an entity', ['Entities'], {
+        pathParams: ['ent_id'],
+        requestBody: 'EntityUpdateRequest',
+        responseType: 'Entity',
+      }),
+    };
+
+    // /entities/{ent_id}/consent
+    this.spec.paths['/entities/{ent_id}/consent'] = {
+      post: this.createOperation('withdrawEntityConsent', 'Withdraw entity consent', ['Entities'], {
+        pathParams: ['ent_id'],
+        requestBody: 'EntityWithdrawConsentRequest',
+        responseType: 'Entity',
+      }),
+    };
+
+    // /entities/{ent_id}/connect
+    this.spec.paths['/entities/{ent_id}/connect'] = {
+      get: this.createOperation('listEntityConnect', 'List entity connect records', ['Entities - Connect'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntityConnect',
+        isList: true,
+      }),
+      post: this.createOperation('createEntityConnect', 'Create entity connect', ['Entities - Connect'], {
+        pathParams: ['ent_id'],
+        requestBody: 'EntityConnectCreateRequest',
+        responseType: 'EntityConnect',
+      }),
+    };
+
+    // /entities/{ent_id}/connect/{cxn_id}
+    this.spec.paths['/entities/{ent_id}/connect/{cxn_id}'] = {
+      get: this.createOperation('retrieveEntityConnect', 'Retrieve entity connect', ['Entities - Connect'], {
+        pathParams: ['ent_id', 'cxn_id'],
+        responseType: 'EntityConnect',
+      }),
+    };
+
+    // /entities/{ent_id}/credit_scores
+    this.spec.paths['/entities/{ent_id}/credit_scores'] = {
+      get: this.createOperation('listEntityCreditScores', 'List entity credit scores', ['Entities - Credit Scores'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntityCreditScores',
+        isList: true,
+      }),
+      post: this.createOperation('createEntityCreditScores', 'Create entity credit scores request', ['Entities - Credit Scores'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntityCreditScores',
+      }),
+    };
+
+    // /entities/{ent_id}/credit_scores/{crs_id}
+    this.spec.paths['/entities/{ent_id}/credit_scores/{crs_id}'] = {
+      get: this.createOperation('retrieveEntityCreditScores', 'Retrieve entity credit scores', ['Entities - Credit Scores'], {
+        pathParams: ['ent_id', 'crs_id'],
+        responseType: 'EntityCreditScores',
+      }),
+    };
+
+    // /entities/{ent_id}/identities
+    this.spec.paths['/entities/{ent_id}/identities'] = {
+      get: this.createOperation('listEntityIdentities', 'List entity identities', ['Entities - Identities'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntityIdentity',
+        isList: true,
+      }),
+      post: this.createOperation('createEntityIdentity', 'Create entity identity request', ['Entities - Identities'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntityIdentity',
+      }),
+    };
+
+    // /entities/{ent_id}/identities/{idn_id}
+    this.spec.paths['/entities/{ent_id}/identities/{idn_id}'] = {
+      get: this.createOperation('retrieveEntityIdentity', 'Retrieve entity identity', ['Entities - Identities'], {
+        pathParams: ['ent_id', 'idn_id'],
+        responseType: 'EntityIdentity',
+      }),
+    };
+
+    // /entities/{ent_id}/attributes
+    this.spec.paths['/entities/{ent_id}/attributes'] = {
+      get: this.createOperation('listEntityAttributes', 'List entity attributes', ['Entities - Attributes'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntityAttributes',
+        isList: true,
+      }),
+      post: this.createOperation('createEntityAttributes', 'Create entity attributes request', ['Entities - Attributes'], {
+        pathParams: ['ent_id'],
+        requestBody: 'EntityAttributesCreateRequest',
+        responseType: 'EntityAttributes',
+      }),
+    };
+
+    // /entities/{ent_id}/attributes/{atr_id}
+    this.spec.paths['/entities/{ent_id}/attributes/{atr_id}'] = {
+      get: this.createOperation('retrieveEntityAttributes', 'Retrieve entity attributes', ['Entities - Attributes'], {
+        pathParams: ['ent_id', 'atr_id'],
+        responseType: 'EntityAttributes',
+      }),
+    };
+
+    // /entities/{ent_id}/vehicles
+    this.spec.paths['/entities/{ent_id}/vehicles'] = {
+      get: this.createOperation('listEntityVehicles', 'List entity vehicles', ['Entities - Vehicles'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntityVehicles',
+        isList: true,
+      }),
+      post: this.createOperation('createEntityVehicles', 'Create entity vehicles request', ['Entities - Vehicles'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntityVehicles',
+      }),
+    };
+
+    // /entities/{ent_id}/vehicles/{vhl_id}
+    this.spec.paths['/entities/{ent_id}/vehicles/{vhl_id}'] = {
+      get: this.createOperation('retrieveEntityVehicles', 'Retrieve entity vehicles', ['Entities - Vehicles'], {
+        pathParams: ['ent_id', 'vhl_id'],
+        responseType: 'EntityVehicles',
+      }),
+    };
+
+    // /entities/{ent_id}/products
+    this.spec.paths['/entities/{ent_id}/products'] = {
+      get: this.createOperation('listEntityProducts', 'List entity products', ['Entities - Products'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntityProductListResponse',
+      }),
+    };
+
+    // /entities/{ent_id}/subscriptions
+    this.spec.paths['/entities/{ent_id}/subscriptions'] = {
+      get: this.createOperation('listEntitySubscriptions', 'List entity subscriptions', ['Entities - Subscriptions'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntitySubscription',
+        isList: true,
+      }),
+      post: this.createOperation('createEntitySubscription', 'Create entity subscription', ['Entities - Subscriptions'], {
+        pathParams: ['ent_id'],
+        requestBody: 'EntitySubscriptionCreateRequest',
+        responseType: 'EntitySubscription',
+      }),
+    };
+
+    // /entities/{ent_id}/subscriptions/{sub_id}
+    this.spec.paths['/entities/{ent_id}/subscriptions/{sub_id}'] = {
+      get: this.createOperation('retrieveEntitySubscription', 'Retrieve entity subscription', ['Entities - Subscriptions'], {
+        pathParams: ['ent_id', 'sub_id'],
+        responseType: 'EntitySubscription',
+      }),
+      delete: this.createOperation('deleteEntitySubscription', 'Delete entity subscription', ['Entities - Subscriptions'], {
+        pathParams: ['ent_id', 'sub_id'],
+        responseType: 'EntitySubscription',
+      }),
+    };
+
+    // /entities/{ent_id}/verification_sessions
+    this.spec.paths['/entities/{ent_id}/verification_sessions'] = {
+      get: this.createOperation('listEntityVerificationSessions', 'List entity verification sessions', ['Entities - Verification Sessions'], {
+        pathParams: ['ent_id'],
+        responseType: 'EntityVerificationSession',
+        isList: true,
+      }),
+      post: this.createOperation('createEntityVerificationSession', 'Create entity verification session', ['Entities - Verification Sessions'], {
+        pathParams: ['ent_id'],
+        requestBody: 'EntityVerificationSessionCreateRequest',
+        responseType: 'EntityVerificationSession',
+      }),
+    };
+
+    // /entities/{ent_id}/verification_sessions/{evf_id}
+    this.spec.paths['/entities/{ent_id}/verification_sessions/{evf_id}'] = {
+      get: this.createOperation('retrieveEntityVerificationSession', 'Retrieve entity verification session', ['Entities - Verification Sessions'], {
+        pathParams: ['ent_id', 'evf_id'],
+        responseType: 'EntityVerificationSession',
+      }),
+      put: this.createOperation('updateEntityVerificationSession', 'Update entity verification session', ['Entities - Verification Sessions'], {
+        pathParams: ['ent_id', 'evf_id'],
+        requestBody: 'EntityVerificationSessionUpdateRequest',
+        responseType: 'EntityVerificationSession',
+      }),
+    };
+  }
+
+  private generateAccountPaths(): void {
+    // /accounts
+    this.spec.paths['/accounts'] = {
+      get: this.createOperation('listAccounts', 'List all accounts', ['Accounts'], {
+        queryParams: ['from_date', 'to_date', 'page', 'page_limit', 'page_cursor', 'status', 'type', 'holder_id', 'expand', 'liability.mch_id', 'liability.type', 'liability.ownership'],
+        responseType: 'Account',
+        isList: true,
+      }),
+      post: this.createOperation('createAccount', 'Create a new account', ['Accounts'], {
+        requestBody: 'AccountCreateRequest',
+        responseType: 'Account',
+      }),
+    };
+
+    // /accounts/{acc_id}
+    this.spec.paths['/accounts/{acc_id}'] = {
+      get: this.createOperation('retrieveAccount', 'Retrieve an account', ['Accounts'], {
+        pathParams: ['acc_id'],
+        queryParams: ['expand'],
+        responseType: 'Account',
+      }),
+    };
+
+    // /accounts/{acc_id}/consent
+    this.spec.paths['/accounts/{acc_id}/consent'] = {
+      post: this.createOperation('withdrawAccountConsent', 'Withdraw account consent', ['Accounts'], {
+        pathParams: ['acc_id'],
+        requestBody: 'AccountWithdrawConsentRequest',
+        responseType: 'Account',
+      }),
+    };
+
+    // Account sub-resources
+    const accountSubResources = [
+      { path: 'balances', name: 'Balance', schema: 'AccountBalance', hasCreate: true },
+      { path: 'card_brands', name: 'CardBrand', schema: 'AccountCardBrand', hasCreate: true },
+      { path: 'payoffs', name: 'Payoff', schema: 'AccountPayoff', hasCreate: true },
+      { path: 'sensitive', name: 'Sensitive', schema: 'AccountSensitive', hasCreate: true, createRequest: 'AccountSensitiveCreateRequest' },
+      { path: 'transactions', name: 'Transaction', schema: 'AccountTransaction', hasCreate: false },
+      { path: 'updates', name: 'Update', schema: 'AccountUpdate', hasCreate: true },
+      { path: 'attributes', name: 'Attributes', schema: 'AccountAttributes', hasCreate: true },
+      { path: 'payment_instruments', name: 'PaymentInstrument', schema: 'AccountPaymentInstrument', hasCreate: true, createRequest: 'AccountPaymentInstrumentCreateRequest' },
+    ];
+
+    for (const subResource of accountSubResources) {
+      const basePath = `/accounts/{acc_id}/${subResource.path}`;
+      const itemPath = `${basePath}/{${subResource.path.slice(0, -1)}_id}`;
+      const tag = `Accounts - ${subResource.name}s`;
+
+      this.spec.paths[basePath] = {
+        get: this.createOperation(`listAccount${subResource.name}s`, `List account ${subResource.path}`, [tag], {
+          pathParams: ['acc_id'],
+          responseType: subResource.schema,
+          isList: true,
+        }),
+      };
+
+      if (subResource.hasCreate) {
+        this.spec.paths[basePath].post = this.createOperation(`createAccount${subResource.name}`, `Create account ${subResource.path.slice(0, -1)}`, [tag], {
+          pathParams: ['acc_id'],
+          requestBody: subResource.createRequest,
+          responseType: subResource.schema,
+        });
+      }
+
+      this.spec.paths[itemPath] = {
+        get: this.createOperation(`retrieveAccount${subResource.name}`, `Retrieve account ${subResource.path.slice(0, -1)}`, [tag], {
+          pathParams: ['acc_id', `${subResource.path.slice(0, -1)}_id`],
+          responseType: subResource.schema,
+        }),
+      };
+    }
+
+    // Account subscriptions
+    this.spec.paths['/accounts/{acc_id}/subscriptions'] = {
+      get: this.createOperation('listAccountSubscriptions', 'List account subscriptions', ['Accounts - Subscriptions'], {
+        pathParams: ['acc_id'],
+        responseType: 'AccountSubscription',
+        isList: true,
+      }),
+      post: this.createOperation('createAccountSubscription', 'Create account subscription', ['Accounts - Subscriptions'], {
+        pathParams: ['acc_id'],
+        requestBody: 'AccountSubscriptionCreateRequest',
+        responseType: 'AccountSubscription',
+      }),
+    };
+
+    this.spec.paths['/accounts/{acc_id}/subscriptions/{sub_id}'] = {
+      get: this.createOperation('retrieveAccountSubscription', 'Retrieve account subscription', ['Accounts - Subscriptions'], {
+        pathParams: ['acc_id', 'sub_id'],
+        responseType: 'AccountSubscription',
+      }),
+      delete: this.createOperation('deleteAccountSubscription', 'Delete account subscription', ['Accounts - Subscriptions'], {
+        pathParams: ['acc_id', 'sub_id'],
+        responseType: 'AccountSubscription',
+      }),
+    };
+
+    // Account products
+    this.spec.paths['/accounts/{acc_id}/products'] = {
+      get: this.createOperation('listAccountProducts', 'List account products', ['Accounts - Products'], {
+        pathParams: ['acc_id'],
+        responseType: 'AccountProduct',
+        isList: true,
+      }),
+    };
+
+    // Account verification sessions
+    this.spec.paths['/accounts/{acc_id}/verification_sessions'] = {
+      get: this.createOperation('listAccountVerificationSessions', 'List account verification sessions', ['Accounts - Verification Sessions'], {
+        pathParams: ['acc_id'],
+        responseType: 'AccountVerificationSession',
+        isList: true,
+      }),
+      post: this.createOperation('createAccountVerificationSession', 'Create account verification session', ['Accounts - Verification Sessions'], {
+        pathParams: ['acc_id'],
+        requestBody: 'AccountVerificationSessionCreateRequest',
+        responseType: 'AccountVerificationSession',
+      }),
+    };
+
+    this.spec.paths['/accounts/{acc_id}/verification_sessions/{avf_id}'] = {
+      get: this.createOperation('retrieveAccountVerificationSession', 'Retrieve account verification session', ['Accounts - Verification Sessions'], {
+        pathParams: ['acc_id', 'avf_id'],
+        responseType: 'AccountVerificationSession',
+      }),
+      put: this.createOperation('updateAccountVerificationSession', 'Update account verification session', ['Accounts - Verification Sessions'], {
+        pathParams: ['acc_id', 'avf_id'],
+        requestBody: 'AccountVerificationSessionUpdateRequest',
+        responseType: 'AccountVerificationSession',
+      }),
+    };
+  }
+
+  private generatePaymentPaths(): void {
+    // /payments
+    this.spec.paths['/payments'] = {
+      get: this.createOperation('listPayments', 'List all payments', ['Payments'], {
+        queryParams: ['from_date', 'to_date', 'page', 'page_limit', 'page_cursor', 'status', 'type', 'source', 'destination', 'reversal_id', 'source_holder_id', 'destination_holder_id', 'acc_id', 'holder_id'],
+        responseType: 'Payment',
+        isList: true,
+      }),
+      post: this.createOperation('createPayment', 'Create a new payment', ['Payments'], {
+        requestBody: 'PaymentCreateRequest',
+        responseType: 'Payment',
+      }),
+    };
+
+    // /payments/{pmt_id}
+    this.spec.paths['/payments/{pmt_id}'] = {
+      get: this.createOperation('retrievePayment', 'Retrieve a payment', ['Payments'], {
+        pathParams: ['pmt_id'],
+        responseType: 'Payment',
+      }),
+      delete: this.createOperation('deletePayment', 'Cancel a payment', ['Payments'], {
+        pathParams: ['pmt_id'],
+        responseType: 'Payment',
+      }),
+    };
+
+    // /payments/{pmt_id}/reversals
+    this.spec.paths['/payments/{pmt_id}/reversals'] = {
+      get: this.createOperation('listPaymentReversals', 'List payment reversals', ['Payments - Reversals'], {
+        pathParams: ['pmt_id'],
+        responseType: 'Reversal',
+        isList: true,
+      }),
+    };
+
+    // /payments/{pmt_id}/reversals/{rvs_id}
+    this.spec.paths['/payments/{pmt_id}/reversals/{rvs_id}'] = {
+      get: this.createOperation('retrievePaymentReversal', 'Retrieve payment reversal', ['Payments - Reversals'], {
+        pathParams: ['pmt_id', 'rvs_id'],
+        responseType: 'Reversal',
+      }),
+      put: this.createOperation('updatePaymentReversal', 'Update payment reversal', ['Payments - Reversals'], {
+        pathParams: ['pmt_id', 'rvs_id'],
+        requestBody: 'ReversalUpdateRequest',
+        responseType: 'Reversal',
+      }),
+    };
+  }
+
+  private generateWebhookPaths(): void {
+    // /webhooks
+    this.spec.paths['/webhooks'] = {
+      get: this.createOperation('listWebhooks', 'List all webhooks', ['Webhooks'], {
+        responseType: 'Webhook',
+        isList: true,
+      }),
+      post: this.createOperation('createWebhook', 'Create a new webhook', ['Webhooks'], {
+        requestBody: 'WebhookCreateRequest',
+        responseType: 'Webhook',
+      }),
+    };
+
+    // /webhooks/{whk_id}
+    this.spec.paths['/webhooks/{whk_id}'] = {
+      get: this.createOperation('retrieveWebhook', 'Retrieve a webhook', ['Webhooks'], {
+        pathParams: ['whk_id'],
+        responseType: 'Webhook',
+      }),
+      patch: this.createOperation('updateWebhook', 'Update a webhook', ['Webhooks'], {
+        pathParams: ['whk_id'],
+        requestBody: 'WebhookUpdateRequest',
+        responseType: 'Webhook',
+      }),
+      delete: this.createOperation('deleteWebhook', 'Delete a webhook', ['Webhooks'], {
+        pathParams: ['whk_id'],
+        responseType: 'object',
+      }),
+    };
+  }
+
+  private generateReportPaths(): void {
+    // /reports
+    this.spec.paths['/reports'] = {
+      post: this.createOperation('createReport', 'Create a new report', ['Reports'], {
+        requestBody: 'ReportCreateRequest',
+        responseType: 'Report',
+      }),
+    };
+
+    // /reports/{rpt_id}
+    this.spec.paths['/reports/{rpt_id}'] = {
+      get: this.createOperation('retrieveReport', 'Retrieve a report', ['Reports'], {
+        pathParams: ['rpt_id'],
+        responseType: 'Report',
+      }),
+    };
+
+    // /reports/{rpt_id}/download
+    this.spec.paths['/reports/{rpt_id}/download'] = {
+      get: {
+        operationId: 'downloadReport',
+        summary: 'Download a report',
+        description: 'Download a report as CSV',
+        tags: ['Reports'],
+        parameters: [
+          {
+            name: 'rpt_id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'Report CSV data',
+            content: {
+              'text/csv': {
+                schema: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    };
+  }
+
+  private generateMerchantPaths(): void {
+    // /merchants
+    this.spec.paths['/merchants'] = {
+      get: this.createOperation('listMerchants', 'List all merchants', ['Merchants'], {
+        queryParams: ['page', 'page_limit', 'type', 'name', 'creditor_name', 'provider_id.plaid', 'provider_id.mx', 'provider_id.finicity', 'provider_id.dpp'],
+        responseType: 'Merchant',
+        isList: true,
+      }),
+    };
+
+    // /merchants/{mch_id}
+    this.spec.paths['/merchants/{mch_id}'] = {
+      get: this.createOperation('retrieveMerchant', 'Retrieve a merchant', ['Merchants'], {
+        pathParams: ['mch_id'],
+        responseType: 'Merchant',
+      }),
+    };
+  }
+
+  private generateEventPaths(): void {
+    // /events
+    this.spec.paths['/events'] = {
+      get: this.createOperation('listEvents', 'List all events', ['Events'], {
+        queryParams: ['from_date', 'to_date', 'page', 'page_limit', 'page_cursor', 'resource_id', 'resource_type', 'type'],
+        responseType: 'Event',
+        isList: true,
+      }),
+    };
+
+    // /events/{evt_id}
+    this.spec.paths['/events/{evt_id}'] = {
+      get: this.createOperation('retrieveEvent', 'Retrieve an event', ['Events'], {
+        pathParams: ['evt_id'],
+        responseType: 'Event',
+      }),
+    };
+  }
+
+  private generateElementPaths(): void {
+    // /elements/token
+    this.spec.paths['/elements/token'] = {
+      post: this.createOperation('createElementToken', 'Create an element token', ['Elements'], {
+        requestBody: 'ElementTokenCreateRequest',
+        responseType: 'ElementToken',
+      }),
+    };
+
+    // /elements/token/{pk_elem_id}/results
+    this.spec.paths['/elements/token/{pk_elem_id}/results'] = {
+      get: this.createOperation('retrieveElementResults', 'Retrieve element results', ['Elements'], {
+        pathParams: ['pk_elem_id'],
+        responseType: 'ElementResults',
+      }),
+    };
+  }
+
+  private generateOpalPaths(): void {
+    // /opal/token
+    this.spec.paths['/opal/token'] = {
+      post: this.createOperation('createOpalToken', 'Create an opal token', ['Opal'], {
+        requestBody: 'OpalTokenCreateRequest',
+        responseType: 'OpalToken',
+      }),
+    };
+  }
+
+  private generateSimulatePaths(): void {
+    // /simulate/payments/{pmt_id}
+    this.spec.paths['/simulate/payments/{pmt_id}'] = {
+      post: this.createOperation('simulatePaymentUpdate', 'Simulate payment status update', ['Simulate'], {
+        pathParams: ['pmt_id'],
+        requestBody: 'SimulatePaymentUpdateRequest',
+        responseType: 'Payment',
+      }),
+    };
+
+    // /simulate/accounts/{acc_id}/transactions
+    this.spec.paths['/simulate/accounts/{acc_id}/transactions'] = {
+      post: this.createOperation('simulateAccountTransaction', 'Simulate account transaction', ['Simulate'], {
+        pathParams: ['acc_id'],
+        responseType: 'AccountTransaction',
+      }),
+    };
+
+    // /simulate/entities/{ent_id}/connect
+    this.spec.paths['/simulate/entities/{ent_id}/connect'] = {
+      post: this.createOperation('simulateEntityConnect', 'Simulate entity connect', ['Simulate'], {
+        pathParams: ['ent_id'],
+        requestBody: 'SimulateEntityConnectRequest',
+        responseType: 'EntityConnect',
+      }),
+    };
+
+    // /simulate/entities/{ent_id}/credit_scores/{crs_id}
+    this.spec.paths['/simulate/entities/{ent_id}/credit_scores/{crs_id}'] = {
+      post: this.createOperation('simulateEntityCreditScores', 'Simulate entity credit scores', ['Simulate'], {
+        pathParams: ['ent_id', 'crs_id'],
+        responseType: 'EntityCreditScores',
+      }),
+    };
+
+    // /simulate/entities/{ent_id}/attributes/{atr_id}
+    this.spec.paths['/simulate/entities/{ent_id}/attributes/{atr_id}'] = {
+      post: this.createOperation('simulateEntityAttributes', 'Simulate entity attributes', ['Simulate'], {
+        pathParams: ['ent_id', 'atr_id'],
+        requestBody: 'SimulateEntityAttributesRequest',
+        responseType: 'EntityAttributes',
+      }),
+    };
+
+    // /simulate/events
+    this.spec.paths['/simulate/events'] = {
+      post: this.createOperation('simulateEvent', 'Simulate an event', ['Simulate'], {
+        responseType: 'Event',
+      }),
+    };
+  }
+
+  private createOperation(
+    operationId: string,
+    summary: string,
+    tags: string[],
+    options: {
+      pathParams?: string[];
+      queryParams?: string[];
+      requestBody?: string;
+      responseType: string;
+      isList?: boolean;
+      description?: string;
+    }
+  ): Operation {
+    const operation: Operation = {
+      operationId,
+      summary,
+      description: options.description || `${summary}. See https://docs.methodfi.com for more details.`,
+      tags,
+      responses: {
+        '200': {
+          description: 'Successful response',
+          content: {
+            'application/json': {
+              schema: options.responseType === 'object'
+                ? { type: 'object' }
+                : options.isList
+                  ? { type: 'array', items: { $ref: `#/components/schemas/${options.responseType}` } }
+                  : { $ref: `#/components/schemas/${options.responseType}` },
+            },
+          },
+        },
+      },
+    };
+
+    const parameters: Parameter[] = [];
+
+    if (options.pathParams) {
+      for (const param of options.pathParams) {
+        parameters.push({
+          name: param,
+          in: 'path',
+          required: true,
+          schema: { type: 'string' },
+        });
+      }
+    }
+
+    if (options.queryParams) {
+      for (const param of options.queryParams) {
+        parameters.push({
+          name: param,
+          in: 'query',
+          required: false,
+          schema: { type: 'string' },
+        });
+      }
+    }
+
+    if (parameters.length > 0) {
+      operation.parameters = parameters;
+    }
+
+    if (options.requestBody) {
+      operation.requestBody = {
+        required: true,
+        content: {
+          'application/json': {
+            schema: { $ref: `#/components/schemas/${options.requestBody}` },
+          },
+        },
+      };
+    }
+
+    return operation;
+  }
+
+  toYAML(): string {
+    return yaml.dump(this.spec, {
+      indent: 2,
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: false,
+    });
+  }
+
+  toJSON(): string {
+    return JSON.stringify(this.spec, null, 2);
+  }
+}
+
+// ============================================================================
+// Main execution
+// ============================================================================
+
+async function main() {
+  const srcDir = path.join(__dirname, '..', 'src');
+  const outputPath = path.join(__dirname, '..', 'openapi.yaml');
+
+  console.log('Parsing TypeScript source files...');
+  const parser = new TypeScriptParser(srcDir);
+  parser.parse();
+
+  console.log('Generating OpenAPI specification...');
+  const generator = new OpenAPIGenerator(
+    parser.getInterfaces(),
+    parser.getEnums(),
+    parser.getTypeAliases()
+  );
+  generator.generate();
+
+  console.log('Writing OpenAPI specification to file...');
+  const yamlOutput = generator.toYAML();
+  fs.writeFileSync(outputPath, yamlOutput, 'utf-8');
+
+  console.log(`OpenAPI specification generated successfully: ${outputPath}`);
+
+  // Also output JSON version
+  const jsonOutputPath = path.join(__dirname, '..', 'openapi.json');
+  fs.writeFileSync(jsonOutputPath, generator.toJSON(), 'utf-8');
+  console.log(`JSON version also generated: ${jsonOutputPath}`);
+}
+
+main().catch((error) => {
+  console.error('Error generating OpenAPI specification:', error);
+  process.exit(1);
+});

--- a/scripts/tsconfig.scripts.json
+++ b/scripts/tsconfig.scripts.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "moduleResolution": "node",
+    "outDir": "../scripts-dist"
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/scripts/validate-openapi.ts
+++ b/scripts/validate-openapi.ts
@@ -1,0 +1,501 @@
+/**
+ * OpenAPI Validation Script
+ *
+ * Validates the generated OpenAPI spec against the actual SDK source files
+ * to ensure they match.
+ */
+
+import * as ts from 'typescript';
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+  summary: {
+    pathsInSpec: number;
+    pathsExpected: number;
+    schemasInSpec: number;
+    interfacesInSdk: number;
+    missingPaths: string[];
+    extraPaths: string[];
+    missingSchemas: string[];
+    propertyMismatches: PropertyMismatch[];
+  };
+}
+
+interface PropertyMismatch {
+  schema: string;
+  property: string;
+  issue: string;
+}
+
+interface OpenAPISpec {
+  paths: { [path: string]: any };
+  components: {
+    schemas: { [name: string]: any };
+  };
+}
+
+interface SDKInterface {
+  name: string;
+  properties: Map<string, { type: string; optional: boolean; nullable: boolean }>;
+}
+
+interface SDKEndpoint {
+  path: string;
+  methods: string[];
+  resource: string;
+}
+
+// Load the OpenAPI spec
+function loadOpenAPISpec(): OpenAPISpec {
+  const specPath = path.join(__dirname, '..', 'openapi.json');
+  if (!fs.existsSync(specPath)) {
+    throw new Error('openapi.json not found. Run npm run generate:openapi first.');
+  }
+  return JSON.parse(fs.readFileSync(specPath, 'utf-8'));
+}
+
+// Parse SDK source files to extract interfaces
+function parseSDKInterfaces(): Map<string, SDKInterface> {
+  const interfaces = new Map<string, SDKInterface>();
+  const srcDir = path.join(__dirname, '..', 'src', 'resources');
+
+  const typeFiles = findTypeFiles(srcDir);
+
+  for (const file of typeFiles) {
+    const sourceFile = ts.createSourceFile(
+      file,
+      fs.readFileSync(file, 'utf-8'),
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    ts.forEachChild(sourceFile, (node) => {
+      if (ts.isInterfaceDeclaration(node)) {
+        const name = node.name.text;
+        const properties = new Map<string, { type: string; optional: boolean; nullable: boolean }>();
+
+        node.members.forEach((member) => {
+          if (ts.isPropertySignature(member) && member.name) {
+            const propName = member.name.getText(sourceFile);
+            const optional = !!member.questionToken;
+            const typeText = member.type ? member.type.getText(sourceFile) : 'any';
+            const nullable = typeText.includes('| null') || typeText.includes('null |');
+
+            properties.set(propName, {
+              type: typeText,
+              optional,
+              nullable
+            });
+          }
+        });
+
+        interfaces.set(name, { name, properties });
+      }
+    });
+  }
+
+  return interfaces;
+}
+
+// Find all types.ts files in the resources directory
+function findTypeFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  function walk(currentDir: string) {
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      } else if (entry.name === 'types.ts') {
+        files.push(fullPath);
+      }
+    }
+  }
+
+  walk(dir);
+  return files;
+}
+
+// Parse SDK resource files to extract endpoints
+function parseSDKEndpoints(): SDKEndpoint[] {
+  const endpoints: SDKEndpoint[] = [];
+  const srcDir = path.join(__dirname, '..', 'src', 'resources');
+
+  // Define expected endpoints based on SDK structure
+  const expectedEndpoints: SDKEndpoint[] = [
+    // Entities
+    { path: '/entities', methods: ['get', 'post'], resource: 'Entity' },
+    { path: '/entities/{ent_id}', methods: ['get', 'put'], resource: 'Entity' },
+    { path: '/entities/{ent_id}/consent', methods: ['post'], resource: 'Entity' },
+    { path: '/entities/{ent_id}/connect', methods: ['get', 'post'], resource: 'EntityConnect' },
+    { path: '/entities/{ent_id}/connect/{cxn_id}', methods: ['get'], resource: 'EntityConnect' },
+    { path: '/entities/{ent_id}/credit_scores', methods: ['get', 'post'], resource: 'EntityCreditScores' },
+    { path: '/entities/{ent_id}/credit_scores/{crs_id}', methods: ['get'], resource: 'EntityCreditScores' },
+    { path: '/entities/{ent_id}/identities', methods: ['get', 'post'], resource: 'EntityIdentity' },
+    { path: '/entities/{ent_id}/identities/{idn_id}', methods: ['get'], resource: 'EntityIdentity' },
+    { path: '/entities/{ent_id}/attributes', methods: ['get', 'post'], resource: 'EntityAttributes' },
+    { path: '/entities/{ent_id}/attributes/{atr_id}', methods: ['get'], resource: 'EntityAttributes' },
+    { path: '/entities/{ent_id}/vehicles', methods: ['get'], resource: 'EntityVehicles' },
+    { path: '/entities/{ent_id}/vehicles/{vhl_id}', methods: ['get'], resource: 'EntityVehicles' },
+    { path: '/entities/{ent_id}/products', methods: ['get'], resource: 'EntityProduct' },
+    { path: '/entities/{ent_id}/subscriptions', methods: ['get', 'post'], resource: 'EntitySubscription' },
+    { path: '/entities/{ent_id}/subscriptions/{sub_id}', methods: ['get', 'delete'], resource: 'EntitySubscription' },
+    { path: '/entities/{ent_id}/verification_sessions', methods: ['get', 'post'], resource: 'EntityVerificationSession' },
+    { path: '/entities/{ent_id}/verification_sessions/{evf_id}', methods: ['get', 'put'], resource: 'EntityVerificationSession' },
+
+    // Accounts
+    { path: '/accounts', methods: ['get', 'post'], resource: 'Account' },
+    { path: '/accounts/{acc_id}', methods: ['get'], resource: 'Account' },
+    { path: '/accounts/{acc_id}/consent', methods: ['post'], resource: 'Account' },
+    { path: '/accounts/{acc_id}/balances', methods: ['get', 'post'], resource: 'AccountBalance' },
+    { path: '/accounts/{acc_id}/balances/{balance_id}', methods: ['get'], resource: 'AccountBalance' },
+    { path: '/accounts/{acc_id}/card_brands', methods: ['get', 'post'], resource: 'AccountCardBrand' },
+    { path: '/accounts/{acc_id}/card_brands/{card_brand_id}', methods: ['get'], resource: 'AccountCardBrand' },
+    { path: '/accounts/{acc_id}/payoffs', methods: ['get', 'post'], resource: 'AccountPayoff' },
+    { path: '/accounts/{acc_id}/payoffs/{payoff_id}', methods: ['get'], resource: 'AccountPayoff' },
+    { path: '/accounts/{acc_id}/sensitive', methods: ['get', 'post'], resource: 'AccountSensitive' },
+    { path: '/accounts/{acc_id}/sensitive/{sensitiv_id}', methods: ['get'], resource: 'AccountSensitive' },
+    { path: '/accounts/{acc_id}/transactions', methods: ['get'], resource: 'AccountTransaction' },
+    { path: '/accounts/{acc_id}/transactions/{transaction_id}', methods: ['get'], resource: 'AccountTransaction' },
+    { path: '/accounts/{acc_id}/updates', methods: ['get', 'post'], resource: 'AccountUpdate' },
+    { path: '/accounts/{acc_id}/updates/{update_id}', methods: ['get'], resource: 'AccountUpdate' },
+    { path: '/accounts/{acc_id}/attributes', methods: ['get'], resource: 'AccountAttributes' },
+    { path: '/accounts/{acc_id}/attributes/{attribute_id}', methods: ['get'], resource: 'AccountAttributes' },
+    { path: '/accounts/{acc_id}/payment_instruments', methods: ['get', 'post'], resource: 'AccountPaymentInstrument' },
+    { path: '/accounts/{acc_id}/payment_instruments/{payment_instrument_id}', methods: ['get'], resource: 'AccountPaymentInstrument' },
+    { path: '/accounts/{acc_id}/subscriptions', methods: ['get', 'post'], resource: 'AccountSubscription' },
+    { path: '/accounts/{acc_id}/subscriptions/{sub_id}', methods: ['get', 'delete'], resource: 'AccountSubscription' },
+    { path: '/accounts/{acc_id}/products', methods: ['get'], resource: 'AccountProduct' },
+    { path: '/accounts/{acc_id}/verification_sessions', methods: ['get', 'post'], resource: 'AccountVerificationSession' },
+    { path: '/accounts/{acc_id}/verification_sessions/{avf_id}', methods: ['get', 'put'], resource: 'AccountVerificationSession' },
+
+    // Payments
+    { path: '/payments', methods: ['get', 'post'], resource: 'Payment' },
+    { path: '/payments/{pmt_id}', methods: ['get', 'delete'], resource: 'Payment' },
+    { path: '/payments/{pmt_id}/reversals', methods: ['get'], resource: 'Reversal' },
+    { path: '/payments/{pmt_id}/reversals/{rvs_id}', methods: ['get', 'put'], resource: 'Reversal' },
+
+    // Webhooks
+    { path: '/webhooks', methods: ['get', 'post'], resource: 'Webhook' },
+    { path: '/webhooks/{whk_id}', methods: ['get', 'patch', 'delete'], resource: 'Webhook' },
+
+    // Reports (no list method in SDK)
+    { path: '/reports', methods: ['post'], resource: 'Report' },
+    { path: '/reports/{rpt_id}', methods: ['get'], resource: 'Report' },
+    { path: '/reports/{rpt_id}/download', methods: ['get'], resource: 'Report' },
+
+    // Merchants
+    { path: '/merchants', methods: ['get'], resource: 'Merchant' },
+    { path: '/merchants/{mch_id}', methods: ['get'], resource: 'Merchant' },
+
+    // Events
+    { path: '/events', methods: ['get'], resource: 'Event' },
+    { path: '/events/{evt_id}', methods: ['get'], resource: 'Event' },
+
+    // Elements
+    { path: '/elements/token', methods: ['post'], resource: 'Element' },
+    { path: '/elements/token/{pk_elem_id}/results', methods: ['get'], resource: 'Element' },
+
+    // Opal
+    { path: '/opal/token', methods: ['post'], resource: 'Opal' },
+
+    // Simulate
+    { path: '/simulate/payments/{pmt_id}', methods: ['post'], resource: 'SimulatePayment' },
+    { path: '/simulate/accounts/{acc_id}/transactions', methods: ['post'], resource: 'SimulateAccount' },
+    { path: '/simulate/entities/{ent_id}/connect', methods: ['post'], resource: 'SimulateEntity' },
+    { path: '/simulate/entities/{ent_id}/credit_scores/{crs_id}', methods: ['post'], resource: 'SimulateEntity' },
+    { path: '/simulate/entities/{ent_id}/attributes/{atr_id}', methods: ['post'], resource: 'SimulateEntity' },
+    { path: '/simulate/events', methods: ['post'], resource: 'SimulateEvent' },
+  ];
+
+  return expectedEndpoints;
+}
+
+// Map SDK interface names to OpenAPI schema names
+function getSchemaNameMapping(): Map<string, string> {
+  return new Map([
+    ['IEntity', 'Entity'],
+    ['IEntityIndividual', 'EntityIndividual'],
+    ['IEntityCorporation', 'EntityCorporation'],
+    ['IEntityAddress', 'EntityAddress'],
+    ['IEntityConnect', 'EntityConnect'],
+    ['IEntityCreditScores', 'EntityCreditScores'],
+    ['IEntityIdentity', 'EntityIdentity'],
+    ['IEntityAttributes', 'EntityAttributes'],
+    ['IEntityVehicles', 'EntityVehicles'],
+    ['IEntityProduct', 'EntityProduct'],
+    ['IEntitySubscription', 'EntitySubscription'],
+    ['IEntityVerificationSession', 'EntityVerificationSession'],
+    ['IAccount', 'Account'],
+    ['IAccountBalance', 'AccountBalance'],
+    ['IAccountCardBrand', 'AccountCardBrand'],
+    ['IAccountPayoff', 'AccountPayoff'],
+    ['IAccountSensitive', 'AccountSensitive'],
+    ['IAccountTransaction', 'AccountTransaction'],
+    ['IAccountUpdate', 'AccountUpdate'],
+    ['IAccountAttributes', 'AccountAttributes'],
+    ['IAccountPaymentInstrument', 'AccountPaymentInstrument'],
+    ['IAccountSubscription', 'AccountSubscription'],
+    ['IAccountVerificationSession', 'AccountVerificationSession'],
+    ['IAccountProduct', 'AccountProduct'],
+    ['IPayment', 'Payment'],
+    ['IReversal', 'Reversal'],
+    ['IWebhook', 'Webhook'],
+    ['IReport', 'Report'],
+    ['IMerchant', 'Merchant'],
+    ['IEvent', 'Event'],
+    ['IElementToken', 'ElementToken'],
+    ['IElementResults', 'ElementResults'],
+    ['IOpalToken', 'OpalToken'],
+  ]);
+}
+
+// Validate paths
+function validatePaths(spec: OpenAPISpec, expectedEndpoints: SDKEndpoint[]): {
+  missing: string[];
+  extra: string[];
+  methodMismatches: string[];
+} {
+  const specPaths = new Set(Object.keys(spec.paths));
+  const expectedPaths = new Set(expectedEndpoints.map(e => e.path));
+
+  const missing = [...expectedPaths].filter(p => !specPaths.has(p));
+  const extra = [...specPaths].filter(p => !expectedPaths.has(p));
+
+  const methodMismatches: string[] = [];
+
+  for (const endpoint of expectedEndpoints) {
+    if (spec.paths[endpoint.path]) {
+      const specMethods = Object.keys(spec.paths[endpoint.path]);
+      for (const method of endpoint.methods) {
+        if (!specMethods.includes(method)) {
+          methodMismatches.push(`${endpoint.path}: missing ${method.toUpperCase()}`);
+        }
+      }
+    }
+  }
+
+  return { missing, extra, methodMismatches };
+}
+
+// Validate schemas against SDK interfaces
+function validateSchemas(
+  spec: OpenAPISpec,
+  sdkInterfaces: Map<string, SDKInterface>,
+  nameMapping: Map<string, string>
+): PropertyMismatch[] {
+  const mismatches: PropertyMismatch[] = [];
+
+  for (const [sdkName, schemaName] of nameMapping) {
+    const sdkInterface = sdkInterfaces.get(sdkName);
+    const schema = spec.components.schemas[schemaName];
+
+    if (!sdkInterface) {
+      continue; // Skip if SDK interface not found
+    }
+
+    if (!schema) {
+      mismatches.push({
+        schema: schemaName,
+        property: '',
+        issue: `Schema not found in OpenAPI spec`
+      });
+      continue;
+    }
+
+    // Check each SDK property exists in schema
+    for (const [propName, propInfo] of sdkInterface.properties) {
+      if (!schema.properties || !schema.properties[propName]) {
+        mismatches.push({
+          schema: schemaName,
+          property: propName,
+          issue: `Property missing in OpenAPI schema`
+        });
+        continue;
+      }
+
+      const schemaProp = schema.properties[propName];
+
+      // Check nullable
+      if (propInfo.nullable && !schemaProp.nullable) {
+        mismatches.push({
+          schema: schemaName,
+          property: propName,
+          issue: `Should be nullable in OpenAPI schema`
+        });
+      }
+
+      // Check required (if property is not optional in SDK, it should be required in schema)
+      if (!propInfo.optional && schema.required && !schema.required.includes(propName)) {
+        // This is a warning, not an error, since we might have different requirements
+      }
+    }
+
+    // Check for extra properties in schema that aren't in SDK
+    if (schema.properties) {
+      for (const propName of Object.keys(schema.properties)) {
+        if (!sdkInterface.properties.has(propName)) {
+          mismatches.push({
+            schema: schemaName,
+            property: propName,
+            issue: `Extra property in OpenAPI schema not in SDK interface`
+          });
+        }
+      }
+    }
+  }
+
+  return mismatches;
+}
+
+// Main validation function
+function validate(): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  console.log('Loading OpenAPI spec...');
+  let spec: OpenAPISpec;
+  try {
+    spec = loadOpenAPISpec();
+  } catch (e) {
+    return {
+      valid: false,
+      errors: [(e as Error).message],
+      warnings: [],
+      summary: {
+        pathsInSpec: 0,
+        pathsExpected: 0,
+        schemasInSpec: 0,
+        interfacesInSdk: 0,
+        missingPaths: [],
+        extraPaths: [],
+        missingSchemas: [],
+        propertyMismatches: []
+      }
+    };
+  }
+
+  console.log('Parsing SDK interfaces...');
+  const sdkInterfaces = parseSDKInterfaces();
+
+  console.log('Parsing SDK endpoints...');
+  const expectedEndpoints = parseSDKEndpoints();
+
+  console.log('Validating paths...');
+  const pathValidation = validatePaths(spec, expectedEndpoints);
+
+  if (pathValidation.missing.length > 0) {
+    errors.push(`Missing paths: ${pathValidation.missing.join(', ')}`);
+  }
+
+  if (pathValidation.extra.length > 0) {
+    warnings.push(`Extra paths in spec: ${pathValidation.extra.join(', ')}`);
+  }
+
+  if (pathValidation.methodMismatches.length > 0) {
+    errors.push(`Method mismatches: ${pathValidation.methodMismatches.join(', ')}`);
+  }
+
+  console.log('Validating schemas...');
+  const nameMapping = getSchemaNameMapping();
+  const propertyMismatches = validateSchemas(spec, sdkInterfaces, nameMapping);
+
+  // Separate critical mismatches from warnings
+  const criticalMismatches = propertyMismatches.filter(m =>
+    m.issue.includes('missing') || m.issue.includes('not found')
+  );
+  const warningMismatches = propertyMismatches.filter(m =>
+    !m.issue.includes('missing') && !m.issue.includes('not found')
+  );
+
+  if (criticalMismatches.length > 0) {
+    for (const m of criticalMismatches) {
+      errors.push(`${m.schema}.${m.property}: ${m.issue}`);
+    }
+  }
+
+  if (warningMismatches.length > 0) {
+    for (const m of warningMismatches) {
+      warnings.push(`${m.schema}.${m.property}: ${m.issue}`);
+    }
+  }
+
+  // Check for missing schemas
+  const missingSchemas: string[] = [];
+  for (const [sdkName, schemaName] of nameMapping) {
+    if (sdkInterfaces.has(sdkName) && !spec.components.schemas[schemaName]) {
+      missingSchemas.push(schemaName);
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+    summary: {
+      pathsInSpec: Object.keys(spec.paths).length,
+      pathsExpected: expectedEndpoints.length,
+      schemasInSpec: Object.keys(spec.components.schemas).length,
+      interfacesInSdk: sdkInterfaces.size,
+      missingPaths: pathValidation.missing,
+      extraPaths: pathValidation.extra,
+      missingSchemas,
+      propertyMismatches
+    }
+  };
+}
+
+// Run validation
+console.log('='.repeat(60));
+console.log('OpenAPI Spec Validation');
+console.log('='.repeat(60));
+console.log('');
+
+const result = validate();
+
+console.log('');
+console.log('='.repeat(60));
+console.log('Validation Summary');
+console.log('='.repeat(60));
+console.log('');
+console.log(`Paths in spec:     ${result.summary.pathsInSpec}`);
+console.log(`Paths expected:    ${result.summary.pathsExpected}`);
+console.log(`Schemas in spec:   ${result.summary.schemasInSpec}`);
+console.log(`Interfaces in SDK: ${result.summary.interfacesInSdk}`);
+console.log('');
+
+if (result.summary.missingPaths.length > 0) {
+  console.log('Missing Paths:');
+  result.summary.missingPaths.forEach(p => console.log(`  - ${p}`));
+  console.log('');
+}
+
+if (result.summary.extraPaths.length > 0) {
+  console.log('Extra Paths (in spec but not expected):');
+  result.summary.extraPaths.forEach(p => console.log(`  - ${p}`));
+  console.log('');
+}
+
+if (result.errors.length > 0) {
+  console.log('Errors:');
+  result.errors.forEach(e => console.log(`  ❌ ${e}`));
+  console.log('');
+}
+
+if (result.warnings.length > 0) {
+  console.log('Warnings:');
+  result.warnings.forEach(w => console.log(`  ⚠️  ${w}`));
+  console.log('');
+}
+
+if (result.valid) {
+  console.log('✅ Validation PASSED');
+} else {
+  console.log('❌ Validation FAILED');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Add scripts to generate OpenAPI 3.0 specification from SDK TypeScript types
- Add validation script to ensure spec matches SDK endpoints
- Add Spectral linting configuration for OpenAPI best practices

## New Files
- `scripts/generate-openapi.ts` - Parses SDK types and generates OpenAPI 3.0 spec
- `scripts/validate-openapi.ts` - Validates generated spec against SDK endpoints
- `scripts/tsconfig.scripts.json` - TypeScript config for scripts
- `scripts/README.md` - Documentation for usage
- `.spectral.yaml` - Spectral linting rules

## Usage
```bash
npm run generate:openapi  # Generate openapi.yaml
npm run validate:openapi  # Validate against SDK
npm run lint:openapi      # Lint the spec
```

## Test plan
- [x] Run `npm run generate:openapi` - generates valid OpenAPI 3.0 spec
- [x] Run `npm run validate:openapi` - validates 64 paths, 109 schemas
- [x] Run `npm run lint:openapi` - passes with 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)