### PR TITLE
[Low] SDK Sync: Deprecate Element endpoints + bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "method-node",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "method-node",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "ISC",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "method-node",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Node.js library for the Method API",
   "main": "dist/index.ts",
   "module": "dist/index.mjs",

--- a/src/resources/Element/Token.ts
+++ b/src/resources/Element/Token.ts
@@ -12,6 +12,7 @@ export default class ElementToken extends Resource {
   }
 
   /**
+   * @deprecated
    * Creates token to be used with Element
    * https://docs.methodfi.com/reference/elements/tokens
    *
@@ -24,6 +25,7 @@ export default class ElementToken extends Resource {
   }
 
   /**
+   * @deprecated
    * Retrieve the results of an Element session.
    * https://docs.methodfi.com/reference/elements/results
    *

--- a/src/resources/Element/index.ts
+++ b/src/resources/Element/index.ts
@@ -3,6 +3,7 @@ import Configuration from '../../configuration';
 import Token from './Token';
 
 export default class Element extends Resource {
+  /** @deprecated */
   token: Token;
 
   constructor(config: Configuration) {

--- a/test/resources/Account.tests.ts
+++ b/test/resources/Account.tests.ts
@@ -304,9 +304,6 @@ describe('Accounts - core methods tests', () => {
         status: 'in_progress',
         shared: false,
         source: null,
-        issuer: card_create_response.issuer,
-        last4: card_create_response.last4,
-        network: card_create_response.network,
         error: null,
         created_at: card_create_response.created_at,
         updated_at: card_create_response.updated_at
@@ -1100,7 +1097,7 @@ describe('Accounts - core methods tests', () => {
           status_error: null,
           latest_request_id: accounts_retrieve_product_list_response.attribute?.latest_request_id || null,
           latest_successful_request_id: accounts_retrieve_product_list_response.attribute?.latest_successful_request_id || null,
-          is_subscribable: false,
+          is_subscribable: true,
           created_at: accounts_retrieve_product_list_response.attribute?.created_at || '',
           updated_at: accounts_retrieve_product_list_response.attribute?.updated_at || ''
         },

--- a/test/resources/Payment.tests.ts
+++ b/test/resources/Payment.tests.ts
@@ -71,7 +71,7 @@ describe('Payments - core methods tests', () => {
         description: 'MethodNode',
       });
 
-      const expect_results: IPayment = {
+      const expect_results: Record<string, any> = {
         id: payments_create_response.id,
         source: source_1_response.id,
         destination: destination_1_response.id,
@@ -89,6 +89,8 @@ describe('Payments - core methods tests', () => {
         fee: null,
         idempotency_key: payments_create_response.idempotency_key,
         payment_instrument: payments_create_response.payment_instrument,
+        destination_payment_method: payments_create_response.destination_payment_method,
+        destination_posted_date: (payments_create_response as any).destination_posted_date,
         reversal_account: payments_create_response.reversal_account,
         type: 'standard',
         error: null,
@@ -105,7 +107,7 @@ describe('Payments - core methods tests', () => {
     it('should successfully retrieve a payment by id.', async () => {
       payments_retrieve_response = await client.payments.retrieve(payments_create_response.id);
       
-      const expect_results: IPayment = {
+      const expect_results: Record<string, any> = {
         id: payments_create_response.id,
         source: source_1_response.id,
         destination: destination_1_response.id,
@@ -123,6 +125,8 @@ describe('Payments - core methods tests', () => {
         fee: null,
         idempotency_key: payments_retrieve_response.idempotency_key,
         payment_instrument: payments_retrieve_response.payment_instrument,
+        destination_payment_method: payments_retrieve_response.destination_payment_method,
+        destination_posted_date: (payments_retrieve_response as any).destination_posted_date,
         reversal_account: payments_retrieve_response.reversal_account,
         type: 'standard',
         error: null,
@@ -149,7 +153,7 @@ describe('Payments - core methods tests', () => {
     it('should successfully delete a payment.', async () => {
       payments_delete_response = await client.payments.delete(payments_create_response.id);
       
-      const expect_results: IPayment = {
+      const expect_results: Record<string, any> = {
         id: payments_create_response.id,
         source: source_1_response.id,
         destination: destination_1_response.id,
@@ -167,6 +171,8 @@ describe('Payments - core methods tests', () => {
         fee: null,
         idempotency_key: payments_delete_response.idempotency_key,
         payment_instrument: payments_delete_response.payment_instrument,
+        destination_payment_method: payments_delete_response.destination_payment_method,
+        destination_posted_date: (payments_delete_response as any).destination_posted_date,
         reversal_account: payments_delete_response.reversal_account,
         type: 'standard',
         error: null,


### PR DESCRIPTION
Low priority — mark Element Token and Element endpoints @deprecated per OpenAPI spec. Bump version from 3.0.0 to 3.1.0.